### PR TITLE
Deprecate config.widget_settings_dir

### DIFF
--- a/orangewidget/workflow/config.py
+++ b/orangewidget/workflow/config.py
@@ -136,6 +136,10 @@ def cache_dir():
     """Return the application cache directory. If the directory path
     does not yet exists then create it.
     """
+    warnings.warn(
+        f"'{__name__}.cache_dir' is deprecated.",
+        DeprecationWarning, stacklevel=2
+    )
     base = QStandardPaths.writableLocation(QStandardPaths.GenericCacheLocation)
     name = QCoreApplication.applicationName()
     version = QCoreApplication.applicationVersion()
@@ -155,6 +159,10 @@ def log_dir():
     """
     Return the application log directory.
     """
+    warnings.warn(
+        f"'{__name__}.log_dir' is deprecated.",
+        DeprecationWarning, stacklevel=2
+    )
     if sys.platform == "darwin":
         name = QCoreApplication.applicationName() or "Orange"
         logdir = os.path.join(os.path.expanduser("~/Library/Logs"), name)

--- a/orangewidget/workflow/config.py
+++ b/orangewidget/workflow/config.py
@@ -1,7 +1,8 @@
 """
-Orange Canvas Configuration
-
+Base (example) Configuration for an Orange Widget based application.
 """
+import warnings
+
 import os
 import sys
 import itertools
@@ -171,9 +172,14 @@ def widget_settings_dir(versioned=True):
     """
     Return the platform dependent directory where widgets save their settings.
 
-    This a subdirectory of ``data_dir(versioned)`` named "widgets"
+    .. deprecated: 4.0.1
     """
-    return os.path.join(data_dir(versioned), "widgets")
+    warnings.warn(
+        f"'{__name__}.widget_settings_dir' is deprecated.",
+        DeprecationWarning, stacklevel=2
+    )
+    from orangewidget.settings import widget_settings_dir
+    return widget_settings_dir(versioned)
 
 
 def widgets_entry_points():

--- a/orangewidget/workflow/mainwindow.py
+++ b/orangewidget/workflow/mainwindow.py
@@ -8,10 +8,9 @@ from AnyQt.QtWidgets import (
 from AnyQt.QtGui import QKeySequence
 
 from orangecanvas.application.canvasmain import CanvasMainWindow
-
-from orangewidget.workflow import config
 from orangewidget.report.owreport import HAVE_REPORT, OWReport
 from orangewidget.workflow.widgetsscheme import WidgetsScheme
+
 
 def _insert_action(mb, menuid, beforeactionid, action):
     # type: (QMenuBar, str, str, QAction) -> bool
@@ -164,10 +163,13 @@ class OWCanvasMainWindow(CanvasMainWindow):
             # Touch a finely crafted file inside the settings directory.
             # The existence of this file is checked by the canvas main
             # function and is deleted there.
-            fname = os.path.join(config.widget_settings_dir(),
-                                 "DELETE_ON_START")
-            os.makedirs(config.widget_settings_dir(), exist_ok=True)
-            with open(fname, "a"):
+            from orangewidget.settings import widget_settings_dir
+            dirname = widget_settings_dir()
+            try:
+                os.makedirs(dirname, exist_ok=True)
+            except (FileExistsError, PermissionError):
+                return
+            with open(os.path.join(dirname, "DELETE_ON_START"), "a"):
                 pass
 
             if not self.close():


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref https://github.com/biolab/orange3/pull/3932#discussion_r302905952

##### Description of changes

Make the `settings.widget_settings_dir` the preferred source with an explicit setter/override.

Deprecate other accessors aliases.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
