### PR TITLE
[FIX] report: Fix an import error when WebView is not available

### DIFF
--- a/orangewidget/report/report.py
+++ b/orangewidget/report/report.py
@@ -147,7 +147,10 @@ class Report:
             name, plot = self._fix_args(name, plot)
 
         from pyqtgraph import PlotWidget, PlotItem, GraphicsWidget, GraphicsView
-        from orangewidget.utils.webview import WebviewWidget
+        try:
+            from orangewidget.utils.webview import WebviewWidget
+        except ImportError:
+            WebviewWidget = None
 
         self.report_name(name)
         if plot is None:
@@ -160,7 +163,7 @@ class Report:
             self.report_html += get_html_img(plot.scene())
         elif isinstance(plot, GraphicsView):
             self.report_html += get_html_img(plot)
-        elif isinstance(plot, WebviewWidget):
+        elif WebviewWidget is not None and isinstance(plot, WebviewWidget):
             try:
                 svg = plot.svg()
             except (IndexError, ValueError):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref https://github.com/biolab/orange3/issues/3661

`report_plot` raises an error when WebviewWidget is not available.

##### Description of changes

Guard against a missing WebviewWidget.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
