### PR TITLE
PDF export with lossless image rendering for Qt>=5.13

### DIFF
--- a/orangewidget/io.py
+++ b/orangewidget/io.py
@@ -101,6 +101,8 @@ class ImgFormat(metaclass=_Registry):
             painter = QtGui.QPainter()
             painter.begin(buffer)
             painter.setRenderHint(QtGui.QPainter.Antialiasing)
+            if QtCore.QT_VERSION >= 0x050D00:
+                painter.setRenderHint(QtGui.QPainter.LosslessImageRendering)
 
             target = cls._get_target(scene, painter, buffer, rect)
             try:

--- a/orangewidget/utils/PDFExporter.py
+++ b/orangewidget/utils/PDFExporter.py
@@ -1,5 +1,6 @@
 from pyqtgraph.exporters.Exporter import Exporter
 
+from AnyQt import QtCore
 from AnyQt.QtWidgets import QGraphicsItem, QApplication
 from AnyQt.QtGui import QPainter, QPdfWriter
 from AnyQt.QtCore import QMarginsF, Qt, QSizeF, QRectF
@@ -33,13 +34,14 @@ class PDFExporter(Exporter):
         pw.setResolution(dpi)
         pw.setPageMargins(QMarginsF(0, 0, 0, 0))
         pw.setPageSizeMM(QSizeF(self.getTargetRect().size()) / dpi * 25.4)
-
         painter = QPainter(pw)
         try:
             self.setExportMode(True, {'antialias': True,
                                       'background': self.background,
                                       'painter': painter})
             painter.setRenderHint(QPainter.Antialiasing, True)
+            if QtCore.QT_VERSION >= 0x050D00:
+                painter.setRenderHint(QPainter.LosslessImageRendering, True)
             self.getScene().render(painter,
                                    QRectF(self.getTargetRect()),
                                    QRectF(self.getSourceRect()))


### PR DESCRIPTION
##### Issue
If LosslessImageRendering is not set, the colors in exported files are off: biolab/orange3#3872



##### Description of changes
Set LosslessImageRendering render hint.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
