### PR TITLE
save_plot: Pass default file name to Save file dialog

### DIFF
--- a/orangewidget/utils/saveplot.py
+++ b/orangewidget/utils/saveplot.py
@@ -8,16 +8,18 @@ from orangewidget.utils import filedialogs
 
 
 # noinspection PyBroadException
-def save_plot(data, file_formats, filename=""):
+def save_plot(data, file_formats, start_dir="", filename=""):
     _LAST_DIR_KEY = "directories/last_graph_directory"
     _LAST_FILTER_KEY = "directories/last_graph_filter"
     settings = QSettings()
-    start_dir = settings.value(_LAST_DIR_KEY, filename)
+    start_dir = settings.value(_LAST_DIR_KEY, start_dir)
     if not start_dir or \
             (not os.path.exists(start_dir) and
              not os.path.exists(os.path.split(start_dir)[0])):
         start_dir = os.path.expanduser("~")
     last_filter = settings.value(_LAST_FILTER_KEY, "")
+    if filename:
+        start_dir = os.path.join(start_dir, filename)
     filename, writer, filter = \
         filedialogs.open_filename_dialog_save(start_dir, last_filter, file_formats)
     if not filename:

--- a/orangewidget/utils/tests/test_save_plot.py
+++ b/orangewidget/utils/tests/test_save_plot.py
@@ -1,0 +1,30 @@
+import os
+import unittest
+from unittest.mock import Mock
+
+from AnyQt.QtWidgets import QFileDialog
+
+from orangewidget.utils.filedialogs import format_filter
+from orangewidget.utils.saveplot import save_plot
+from orangewidget.widget import OWBaseWidget
+
+
+class TestSavePlot(unittest.TestCase):
+    def setUp(self):
+        QFileDialog.getSaveFileName = Mock(return_value=[None, None])
+        self.filters = [format_filter(f) for f in OWBaseWidget.graph_writers]
+
+    def test_save_plot(self):
+        save_plot(None, OWBaseWidget.graph_writers)
+        QFileDialog.getSaveFileName.assert_called_once_with(
+            None, "Save as...", os.path.expanduser("~"),
+            ";;".join(self.filters), self.filters[0]
+        )
+
+    def test_save_plot_default_filename(self):
+        save_plot(None, OWBaseWidget.graph_writers, filename="temp.txt")
+        path = os.path.join(os.path.expanduser("~"), "temp.txt")
+        QFileDialog.getSaveFileName.assert_called_once_with(
+            None, "Save as...", path,
+            ";;".join(self.filters), self.filters[0]
+        )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
It is not possible to pass default file name to Save graph dialog. 

##### Description of changes
Enable passing default file name to the dialog.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
