### PR TITLE
gui: Add auto_send and auto_apply convenience functions

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -1530,6 +1530,38 @@ def auto_commit(widget, master, value, label, auto_label=None, box=True,
     return b
 
 
+def auto_send(widget, master, value="auto_send", **kwargs):
+    """
+    Convenience function that creates an auto_commit box,
+    for widgets that send selected data (as opposed to applying changes).
+
+    :param widget: the widget into which the box with the button is inserted
+    :type widget: QWidget or None
+    :param master: master widget
+    :type master: OWBaseWidget or OWComponent
+    :param value: the master's attribute which stores whether the auto-commit (default 'auto_send')
+    :type value:  str
+    :return: the box
+    """
+    return auto_commit(widget, master, value, "Send Selection", "Send Automatically", **kwargs)
+
+
+def auto_apply(widget, master, value="auto_apply", **kwargs):
+    """
+    Convenience function that creates an auto_commit box,
+    for widgets that apply changes (as opposed to sending a selection).
+
+    :param widget: the widget into which the box with the button is inserted
+    :type widget: QWidget or None
+    :param master: master widget
+    :type master: OWBaseWidget or OWComponent
+    :param value: the master's attribute which stores whether the auto-commit (default 'auto_apply')
+    :type value:  str
+    :return: the box
+    """
+    return auto_commit(widget, master, value, "Apply", "Apply Automatically", **kwargs)
+
+
 def connectControl(master, value, f, signal,
                    cfront, cback=None, cfunc=None, fvcb=None):
     cback = cback or value and ValueCallback(master, value, fvcb)


### PR DESCRIPTION
##### Issue
https://github.com/biolab/orange3/issues/3910


##### Description of changes
Added `auto_send` and `auto_apply` convenience functions wrapping `auto_commit`, to expose a more appropriate interface to programmers, encouraging a consolidation in widget interface style, while making a distinction between widgets that apply changes and widgets that send selected data.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
