### PR TITLE
errorreporting: Remove mac address as default machine ID

### DIFF
--- a/orangewidget/workflow/errorreporting.py
+++ b/orangewidget/workflow/errorreporting.py
@@ -264,7 +264,7 @@ class ErrorReporting(QDialog):
             platform.python_version(), platform.system(), platform.release(),
             platform.version(), platform.machine())
         data[F.INSTALLED_PACKAGES] = packages
-        data[F.MACHINE_ID] = machine_id or str(uuid.getnode())
+        data[F.MACHINE_ID] = machine_id
         data[F.STACK_TRACE] = stacktrace
         if err_locals:
             data[F.LOCALS] = err_locals


### PR DESCRIPTION
##### Description of changes
Currently, if `machine-id` is set to empty string, it [defaults to the system's mac address](https://docs.python.org/2/library/uuid.html#uuid.getnode).
The user should be able to set their machine ID to an empty string.

##### Corresponding pull request
To be merged after https://github.com/biolab/orange3/pull/3999.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
