### PR TITLE
Use bound signals in `WidgetTest.send_signal` and `get_output`

### DIFF
--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -252,7 +252,15 @@ class WidgetTest(GuiTest):
             The amount of time to wait for the widget to complete.
         """
         if widget is None:
-            widget = self.widget
+            widgets = {signal.widget for signal, _ in signals
+                       if hasattr(signal, "widget")}
+            if not widgets:
+                widget = self.widget
+            elif len(widgets) == 1:
+                widget = widgets.pop()
+            else:
+                raise ValueError("Signals are bound to different widgets")
+
         for input, value in signals:
             self._send_signal(widget, input, value, *args)
         widget.handleNewSignals()
@@ -332,7 +340,7 @@ class WidgetTest(GuiTest):
         The last sent value of given output or None if nothing has been sent.
         """
         if widget is None:
-            widget = self.widget
+            widget = getattr(output, "widget", self.widget)
 
         if widget.isBlocking() and wait >= 0:
             spy = QSignalSpy(widget.blockingStateChanged)


### PR DESCRIPTION
##### Issue

The following code doesn't send a signal to widget `w` but to `self.widget` although signals are specified as `w.Inputs.data` and `w.Outputs.selected_data`:

``` 
        w = self.create_widget(OWSomeWidget)
        self.send_signal(w.Inputs.data, data)
        out = self.get_output(w.Outputs.selected_data)
```

To make it work, the widget has to be given explicitly:

``` 
        w = self.create_widget(OWSomeWidget)
        self.send_signal(w.Inputs.data, data, widget=w)
        out = self.get_output(w.Outputs.selected_data, widget=w)
```

This bites me every time I manually construct a widget in a test, for instance to test settings.

##### Description of changes

Outputs are already bound to widgets, so we simply use `w.Outputs.selected_data.widget` as default.

Inputs are not yet bound, but it's a simple change and although this is needed only for tests, it's not a big change so it's worth it.

`send_signals` accepts multiple signals. They all need to be bound to the same widget, otherwise an exception is raised.

