### PR TITLE
Amend auto_commit docstring

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -1428,6 +1428,8 @@ def auto_commit(widget, master, value, label, auto_label=None, box=True,
     """
     Add a commit button with auto-commit check box.
 
+    When possible, use auto_apply or auto_send instead of auto_commit.
+
     The widget must have a commit method and a setting that stores whether
     auto-commit is on.
 


### PR DESCRIPTION
##### Issue
https://github.com/biolab/orange3/issues/3910

##### Description of changes
Amend auto_commit docstring, encouraging developers to use `auto_apply` or `auto_send` instead.

##### Includes
- [X] Documentation
