### PR TITLE
WidgetScheme: Fix crashes when saving

### DIFF
--- a/orangewidget/workflow/widgetsscheme.py
+++ b/orangewidget/workflow/widgetsscheme.py
@@ -92,7 +92,11 @@ class WidgetsScheme(Scheme):
         changed = False
         for node in self.nodes:
             settings = self.widget_manager.widget_settings_for_node(node)
-            if settings != node.properties:
+            try:
+                prop_changed = settings != node.properties
+            except ValueError:  # this happens (for instance) on np.array
+                prop_changed = True
+            if prop_changed:
                 node.properties = settings
                 changed = True
         log.debug("Scheme node properties sync (changed: %s)", changed)


### PR DESCRIPTION
##### Issue

Saving files in `WidgetScheme.sync_node_properties`, which crashed for settings of type `np.array`.

This forced us to save selections in Silhouette as list.

##### Description of changes

We discussed three options:

- not allowing `np.array` as setting; 
    - pro: are pickles guaranteed to work across different versions of numpy? Probably not, but they're unlikely not to change;
    - against: all reasonable types are allowed so one would expect arrays to work. There is no good way to police/test this;
- testing whether the setting is `np.array` and calling `np.any` in this case:
    - pro: this is the only way to really know whether the setting has changed
    - against: orange-widget-base should not depend on numpy (currently it does because of pyqtgraph, but we'd like to get rid of it)
- enclose the condition in try-except and assume it changed if an exception is raised.

This PR does the latter, but catches only `ValueError`, which is raised by numpy. Should some other type raise some other expection, this should prompt us to think about whether to allow this type as a setting or not.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
