### PR TITLE
Short names for widgets whose name elides in toolbox

### DIFF
--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -97,6 +97,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
     #: Widget name (:class:`str`) as presented in the Canvas
     name = None
+    short_name = None
     id = None
     category = None
     version = None
@@ -293,7 +294,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         properties = {name: getattr(cls, name) for name in
                       ("name", "icon", "description", "priority", "keywords",
                        "help", "help_ref", "url",
-                       "version", "background", "replaces")}
+                       "version", "background", "replaces", "short_name")}
         properties["id"] = cls.id or cls.__module__
         properties["inputs"] = cls.get_signals("inputs")
         properties["outputs"] = cls.get_signals("outputs")


### PR DESCRIPTION
##### Relevant PRs
https://github.com/biolab/orange3/pull/4056
https://github.com/biolab/orange-canvas-core/pull/31

##### Description of changes
In an effort to avoid eliding text in the toolbox, a `short_name` property was added to widgets and `WidgetDescription`, which overrides the text in the toolbox.

##### Includes
- [X] Code changes
