### PR TITLE
gui.IndicatorItemDelegate: Allow setting indicator color

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -2023,9 +2023,13 @@ class IndicatorItemDelegate(QtWidgets.QStyledItemDelegate):
         indicator = index.data(self.role)
 
         if indicator:
+            brush = index.data(Qt.ForegroundRole)
+            if brush is None:
+                brush = QtGui.QBrush(Qt.black)
             painter.save()
             painter.setRenderHints(QtGui.QPainter.Antialiasing)
-            painter.setBrush(QtGui.QBrush(Qt.black))
+            painter.setBrush(brush)
+            painter.setPen(QtGui.QPen(brush, 1))
             painter.drawEllipse(rect.center(),
                                 self.indicatorSize, self.indicatorSize)
             painter.restore()


### PR DESCRIPTION
Uses ForegroundRole for the indicator color.

This will be used by Data sets widget to indicate the currently output data set (see
https://github.com/biolab/orange3/pull/4071).