### PR TITLE
Fix incorrectly set machine id

### DIFF
--- a/orangewidget/workflow/errorreporting.py
+++ b/orangewidget/workflow/errorreporting.py
@@ -231,7 +231,7 @@ class ErrorReporting(QDialog):
         if settings.contains('error-reporting/machine-id'):
             machine_id = settings.value('error-reporting/machine-id')
         else:
-            machine_id = uuid.uuid4()
+            machine_id = str(uuid.uuid4())
             settings.setValue('error-reporting/machine-id', machine_id)
 
         # If this exact error was already reported in this session,


### PR DESCRIPTION
##### Description of changes
In certain cases, the UUID python object was written to config as `machine_id` instead of a string. This change casts it to string before writing it to config.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation