### PR TITLE
[ENH] StateInfo: add auto format for numbers

### DIFF
--- a/doc/source/tutorial-utilities.rst
+++ b/doc/source/tutorial-utilities.rst
@@ -140,6 +140,9 @@ Widgets can optionally summarize their inputs/outputs via the
    self.info.set_input_summary("foo")
    self.info.set_output_summary("bar")
 
+If an integer is given, the summary automatically formats it using metric
+suffixes and adds the full number as the tooltip.
+
 Summaries are then displayed in the widget's status bar:
 
 .. image:: images/io-summary.png
@@ -170,7 +173,8 @@ in tool tip or popup::
 
 .. seealso::
    :func:`~orangewidget.widget.StateInfo.set_input_summary`,
-   :func:`~orangewidget.widget.StateInfo.set_output_summary`
+   :func:`~orangewidget.widget.StateInfo.set_output_summary`,
+   :func:`~orangewidget.widget.StateInfo.format_number`
 
 
 .. note::

--- a/doc/source/widget.rst
+++ b/doc/source/widget.rst
@@ -174,6 +174,10 @@ Class Member Documentation
    .. function:: set_input_summary(brief:str, detailed:str="", \
                     icon:QIcon=QIcon, format:Qt.TextFormat=Qt.PlainText)
 
+   .. function:: set_input_summary(number:int)
+
+      Automatically format number with metric suffixes and set it as input summary.
+
    .. function:: set_output_summary(summary: Optional[StateInfo.Summary]])
 
       Set the output summary description.
@@ -183,6 +187,14 @@ Class Member Documentation
 
    .. function:: set_output_summary(brief:str, detailed:str="", \
                     icon:QIcon=QIcon, format:Qt.TextFormat=Qt.PlainText)
+
+   .. function:: set_output_summary(number:int)
+
+      Automatically format number with metric suffixes and set it as output summary.
+
+   .. function:: format_number(n:int) -> str
+
+      Format integers larger then 9999 with metric suffix and at most 3 digits.
 
    .. autoattribute:: input_summary_changed(message: StateInfo.Message)
 

--- a/orangewidget/tests/test_widget.py
+++ b/orangewidget/tests/test_widget.py
@@ -13,7 +13,7 @@ from AnyQt.QtTest import QSignalSpy, QTest
 from orangewidget.gui import OWComponent
 from orangewidget.settings import Setting, SettingProvider
 from orangewidget.tests.base import WidgetTest
-from orangewidget.widget import OWBaseWidget, Msg
+from orangewidget.widget import OWBaseWidget, Msg, StateInfo
 from orangewidget.utils.messagewidget import MessagesWidget
 
 
@@ -430,6 +430,13 @@ class WidgetTestInfoSummary(WidgetTest):
         self.assertEqual(inmsg.summarize().text, "Foo")
         self.assertFalse(inmsg.summarize().icon.isNull())
 
+        info.set_input_summary(12_345)
+        info.set_output_summary(1234)
+
+        self.assertEqual(inmsg.summarize().text, "12.3k")
+        self.assertEqual(inmsg.summarize().informativeText, "12345")
+        self.assertEqual(outmsg.summarize().text, "1234")
+
         info.set_input_summary("Foo", "A foo that bars",)
 
         info.set_input_summary(None)
@@ -455,3 +462,16 @@ class WidgetTestInfoSummary(WidgetTest):
 
         with self.assertRaises(TypeError):
             info.set_output_summary(info.NoOutput, "a")
+
+        with self.assertRaises(TypeError):
+            info.set_output_summary(1234, "a")
+
+    def test_format_number(self):
+        self.assertEqual(StateInfo.format_number(9999), "9999")
+        self.assertEqual(StateInfo.format_number(12_345), "12.3k")
+        self.assertEqual(StateInfo.format_number(12_000), "12k")
+        self.assertEqual(StateInfo.format_number(123_456), "123k")
+        self.assertEqual(StateInfo.format_number(99_999), "100k")
+        self.assertEqual(StateInfo.format_number(1_234_567), "1.23M")
+        self.assertEqual(StateInfo.format_number(999_999), "1M")
+        self.assertEqual(StateInfo.format_number(1_000_000), "1M")


### PR DESCRIPTION
##### Issue
Displaying large numbers in i/o summary takes a lot of space.
##### Description of changes
Shorten large numbers using metric suffixes.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
