### PR TITLE
Context: Add __eq__ and __hash__

### DIFF
--- a/orangewidget/settings.py
+++ b/orangewidget/settings.py
@@ -693,7 +693,7 @@ class ContextSetting(Setting):
 
 
 class Context:
-    """Class for data thad defines context and
+    """Class for data that defines context and
     values that should be applied to widget if given context
     is encountered."""
     def __init__(self, **argkw):
@@ -707,6 +707,13 @@ class Context:
             if nc in state:
                 del state[nc]
         return state
+
+    def __eq__(self, other):
+        self_state = self.__getstate__()
+        del self_state["time"]
+        other_state = other.__getstate__()
+        del other_state["time"]
+        return self_state == other_state
 
 
 class ContextHandler(SettingsHandler):

--- a/orangewidget/settings.py
+++ b/orangewidget/settings.py
@@ -701,17 +701,10 @@ class Context:
         self.values = {}
         self.__dict__.update(argkw)
 
-    def __getstate__(self):
-        state = dict(self.__dict__)
-        for nc in getattr(self, "no_copy", []):
-            if nc in state:
-                del state[nc]
-        return state
-
     def __eq__(self, other):
-        self_state = self.__getstate__()
+        self_state = self.__dict__.copy()
         del self_state["time"]
-        other_state = other.__getstate__()
+        other_state = other.__dict__.copy()
         del other_state["time"]
         return self_state == other_state
 

--- a/orangewidget/tests/test_context_handler.py
+++ b/orangewidget/tests/test_context_handler.py
@@ -247,3 +247,14 @@ class TestSettingsPrinter(TestCase):
         self.assertIn("param2=2", output)
         self.assertIn("param1=3", output)
         self.assertIn("param2=4", output)
+
+
+class TestContext(TestCase):
+    def test_context_eq(self):
+        context1 = Context(x=12, y=["a", "list"], time=3.14)
+        context2 = Context(x=12, y=["a", "list"], time=2.71)
+        context3 = Context(x=13, y=["a", "list"], time=2.71)
+        self.assertTrue(context1 == context2)
+        self.assertFalse(context2 == context3)
+
+        self.assertRaises(TypeError, hash, context1)


### PR DESCRIPTION
##### Issue

Fixes https://github.com/biolab/orange3/issues/4185.

As @ales-erjavec explained, Orange always asks whether to save the schema (at least) if if contains widgets with context settings. This happens because context settings are never equal.

##### Description of changes

This PR provides `Contexts.__eq__` (and, for consistency, also `Context.__hash__`) that ignore time stamps. This should solve a general problem, but individual widgets may still have hidden modified values.

##### Includes
- [X] Code changes
