### PR TITLE
gui.checkBox: Show specific state when disabled

### DIFF
--- a/orangewidget/tests/test_gui.py
+++ b/orangewidget/tests/test_gui.py
@@ -74,3 +74,131 @@ class TestDelayedNotification(WidgetTest):
         # notification should not be called again
         with self.assertRaises(TimeoutError):
             self.process_events(lambda: len(call.call_args_list) > 1, timeout=1000)
+
+
+class TestCheckBoxWithDisabledState(GuiTest):
+    def test_check_checkbox_disable_false(self):
+        widget = OWBaseWidget()
+        widget.some_option = False
+        cb = gui.checkBox(widget, widget, "some_option", "foo",
+                          stateWhenDisabled=False)
+        self.assertFalse(cb.isChecked())
+        cb.setEnabled(False)
+        self.assertFalse(cb.isChecked())
+        widget.some_option = True
+        self.assertFalse(cb.isChecked())
+        cb.setEnabled(True)
+        self.assertTrue(cb.isChecked())
+        widget.some_option = False
+        self.assertFalse(cb.isChecked())
+
+        cb.setDisabled(True)
+        self.assertFalse(cb.isChecked())
+        widget.some_option = True
+        self.assertFalse(cb.isChecked())
+        cb.setDisabled(False)
+        self.assertTrue(cb.isChecked())
+        widget.some_option = False
+        self.assertFalse(cb.isChecked())
+
+    def test_check_checkbox_disable_true(self):
+        widget = OWBaseWidget()
+        widget.some_option = False
+        cb = gui.checkBox(widget, widget, "some_option", "foo",
+                          stateWhenDisabled=True)
+        self.assertFalse(cb.isChecked())
+        cb.setEnabled(False)
+        self.assertTrue(cb.isChecked())
+        widget.some_option = True
+        self.assertTrue(cb.isChecked())
+        cb.setEnabled(True)
+        self.assertTrue(cb.isChecked())
+        widget.some_option = False
+        self.assertFalse(cb.isChecked())
+
+        cb.setDisabled(True)
+        self.assertTrue(cb.isChecked())
+        widget.some_option = True
+        self.assertTrue(cb.isChecked())
+        cb.setDisabled(False)
+        self.assertTrue(cb.isChecked())
+        widget.some_option = False
+        self.assertFalse(cb.isChecked())
+
+    def test_clicks(self):
+        widget = OWBaseWidget()
+        widget.some_option = False
+        cb = gui.checkBox(widget, widget, "some_option", "foo",
+                          stateWhenDisabled=False)
+        cb.clicked.emit(True)
+        cb.setEnabled(False)
+        cb.setEnabled(True)
+        self.assertTrue(cb.isChecked())
+
+    def test_set_checked(self):
+        widget = OWBaseWidget()
+
+        widget.some_option = False
+        cb = gui.checkBox(widget, widget, "some_option", "foo",
+                          stateWhenDisabled=False)
+        self.assertFalse(cb.isChecked())
+        cb.setEnabled(False)
+        cb.setChecked(True)
+        self.assertFalse(cb.isChecked())
+        cb.setEnabled(True)
+        self.assertTrue(cb.isChecked())
+
+        widget.some_option = True
+        cb = gui.checkBox(widget, widget, "some_option", "foo",
+                          stateWhenDisabled=True)
+        self.assertTrue(cb.isChecked())
+        cb.setEnabled(False)
+        cb.setChecked(False)
+        self.assertTrue(cb.isChecked())
+        cb.setEnabled(True)
+        self.assertFalse(cb.isChecked())
+
+    def test_set_check_state(self):
+        widget = OWBaseWidget()
+
+        widget.some_option = 0
+        cb = gui.checkBox(widget, widget, "some_option", "foo",
+                          stateWhenDisabled=Qt.Unchecked)
+        cb.setCheckState(Qt.Unchecked)
+        cb.setEnabled(False)
+        self.assertEqual(cb.checkState(), Qt.Unchecked)
+
+        cb.setCheckState(Qt.PartiallyChecked)
+        self.assertEqual(cb.checkState(), Qt.Unchecked)
+        cb.setEnabled(True)
+        self.assertEqual(cb.checkState(), Qt.PartiallyChecked)
+        cb.setEnabled(False)
+        self.assertEqual(cb.checkState(), Qt.Unchecked)
+
+        cb.setCheckState(Qt.Checked)
+        self.assertEqual(cb.checkState(), Qt.Unchecked)
+        cb.setEnabled(True)
+        self.assertEqual(cb.checkState(), Qt.Checked)
+        cb.setEnabled(False)
+        self.assertEqual(cb.checkState(), Qt.Unchecked)
+
+        widget.some_option = 2
+        cb = gui.checkBox(widget, widget, "some_option", "foo",
+                          stateWhenDisabled=Qt.PartiallyChecked)
+        cb.setCheckState(Qt.Unchecked)
+        cb.setEnabled(False)
+        self.assertEqual(cb.checkState(), Qt.PartiallyChecked)
+
+        cb.setCheckState(Qt.Unchecked)
+        self.assertEqual(cb.checkState(), Qt.PartiallyChecked)
+        cb.setEnabled(True)
+        self.assertEqual(cb.checkState(), Qt.Unchecked)
+        cb.setEnabled(False)
+        self.assertEqual(cb.checkState(), Qt.PartiallyChecked)
+
+        cb.setCheckState(Qt.Checked)
+        self.assertEqual(cb.checkState(), Qt.PartiallyChecked)
+        cb.setEnabled(True)
+        self.assertEqual(cb.checkState(), Qt.Checked)
+        cb.setEnabled(False)
+        self.assertEqual(cb.checkState(), Qt.PartiallyChecked)


### PR DESCRIPTION
##### Issue

Closes #24.

Freshly needed in https://github.com/biolab/orange-widget-base/issues/24, but also applicable in probably any widget that disables check boxes.

In understand that this perpetuates the infamous `gui` module. But *if you're going through hell, keep going* (saith Churchill), and (1) `gui` is not that evil and (2) to have this functionality, someone would have to store the hidden and true states anyway, so it's more practical to have a QCheckBox variant with specific state when disabled.

For testing, try adding argument `stateWhenDisabled=False` to check box for `show_probs` in `OWDistributions` (see patch). Check the check box "Show probabilities"; set "Split by" to "None" (check box will be disabled and also cleared); set "Split by" back to some variable (check box will be enabled and checked).

```
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -340,7 +340,9 @@ class OWDistributions(OWWidget):
             callback=self.replot)
         gui.checkBox(
             box, self, "show_probs", "Show probabilities",
-            callback=self._on_show_probabilities_changed)
+            callback=self._on_show_probabilities_changed,
+            stateWhenDisabled=False
+        )
```

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
