### PR TITLE
Error Reporting: Fix sending report with empty ows

### DIFF
--- a/orangewidget/workflow/errorreporting.py
+++ b/orangewidget/workflow/errorreporting.py
@@ -156,12 +156,6 @@ class ErrorReporting(QDialog):
         F = self.DataField
         data = self._data.copy()
 
-        if QSettings().value('error-reporting/add-scheme', True, type=bool):
-            data[F.WIDGET_SCHEME] = data['_' + F.WIDGET_SCHEME]
-        else:
-            data.pop(F.WIDGET_SCHEME, None)
-        del data['_' + F.WIDGET_SCHEME]
-
         def _post_report(data):
             MAX_RETRIES = 2
             for _retry in range(MAX_RETRIES):
@@ -253,17 +247,17 @@ class ErrorReporting(QDialog):
         if widget_class is not None:
             data[F.WIDGET_NAME] = widget_class.name
             data[F.WIDGET_MODULE] = widget_module
-        if workflow is not None:
+        if workflow is not None \
+                and QSettings().value('reporting/add-scheme', True, type=bool):
             fd, filename = mkstemp(prefix='ows-', suffix='.ows.xml')
             os.close(fd)
-            with open(filename, "wb") as f:
-                try:
+            try:
+                with open(filename, "wb") as f:
                     workflow.save_to(f, pretty=True, pickle_fallback=True)
-                except Exception:
-                    pass
-            data[F.WIDGET_SCHEME] = filename
-            with open(filename, encoding='utf-8') as f:
-                data['_' + F.WIDGET_SCHEME] = f.read()
+                with open(filename, encoding='utf-8') as f:
+                    data[F.WIDGET_SCHEME] = f.read()
+            except Exception:
+                pass
         data[F.VERSION] = QApplication.applicationVersion()
         data[F.ENVIRONMENT] = 'Python {} on {} {} {} {}'.format(
             platform.python_version(), platform.system(), platform.release(),


### PR DESCRIPTION
##### Description of changes
In a land far away, when a user unchecked the 'Send workflow' button in the error reporting dialogue, the .ows's filename was sent instead. About two years ago, a commit removed the filename from the report just before it was sent, in a way that threw an exception if the workflow was empty.

This likely led to some orangecanvas exceptions not being sent.

Not quite sure how `mkstemp` works, so I left the logic there as is.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
