### PR TITLE
WidgetTest: Check types of settings

### DIFF
--- a/orangewidget/settings.py
+++ b/orangewidget/settings.py
@@ -41,6 +41,8 @@ import warnings
 from operator import itemgetter
 from typing import Any, Optional, Tuple
 
+import numpy as np
+
 from orangewidget.gui import OWComponent
 
 log = logging.getLogger(__name__)
@@ -48,7 +50,8 @@ log = logging.getLogger(__name__)
 __all__ = [
     "Setting", "SettingsHandler", "SettingProvider",
     "ContextSetting", "Context", "ContextHandler", "IncompatibleContext",
-    "SettingsPrinter", "rename_setting", "widget_settings_dir"
+    "SettingsPrinter", "rename_setting", "widget_settings_dir",
+    "is_setting_type_supported"
 ]
 
 _IMMUTABLES = (str, int, bytes, bool, float, tuple)
@@ -57,6 +60,32 @@ VERSION_KEY = "__version__"
 
 
 __WIDGET_SETTINGS_DIR = None  # type: Optional[Tuple[str, str]]
+
+
+def is_setting_type_supported(value: Any) -> bool:
+    """
+    Check validity of setting type.
+
+    Parameters
+    ----------
+    value: object
+        Value of the setting.
+
+    Returns
+    -------
+    bool
+        Return True if the setting type is valid.
+    """
+    if value is None or isinstance(value, (int, float, str, bytes,
+                                           np.integer)):
+        return True
+    elif isinstance(value, (dict, list, tuple, set, frozenset)):
+        values = value.values() if isinstance(value, dict) else value
+        for val in values:
+            if not is_setting_type_supported(val):
+                return False
+        return True
+    return False
 
 
 def set_widget_settings_dir_components(basedir: str, versionstr: str) -> None:

--- a/orangewidget/tests/test_settings.py
+++ b/orangewidget/tests/test_settings.py
@@ -1,0 +1,30 @@
+import unittest
+
+from orangewidget.settings import is_setting_type_supported
+
+
+class TestSupportedSettingTypes(unittest.TestCase):
+    def test_primitive_types(self):
+        self.assertTrue(is_setting_type_supported(None))
+        self.assertTrue(is_setting_type_supported(0))
+        self.assertTrue(is_setting_type_supported(0.1))
+        self.assertTrue(is_setting_type_supported("foo"))
+        self.assertTrue(is_setting_type_supported(bytes(1)))
+
+    def test_composite_types(self):
+        self.assertTrue(is_setting_type_supported(["foo", "bar"]))
+        self.assertTrue(is_setting_type_supported(("foo", "bar")))
+        self.assertTrue(is_setting_type_supported({"foo": 1, "bar": 2}))
+        self.assertTrue(is_setting_type_supported(set(("foo", "bar"))))
+        self.assertTrue(is_setting_type_supported(frozenset(("foo", "bar"))))
+        self.assertFalse(is_setting_type_supported(range(2)))
+
+    def test_nested_types(self):
+        values = [[1, 2], (2, (3, 4, ["Foo", set(("foo", "bar"))]))]
+        self.assertTrue(is_setting_type_supported(values))
+        values = [[1, 2], (2, (3, 4, ["Foo", range(3)]))]
+        self.assertFalse(is_setting_type_supported(values))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #20

##### Description of changes
Add settings checking into `tearDown` of `WidgetTest`.
The change causes the following tests (in biolab/orange3) to fail:

- [ ] test_owcolor (saves`Orange.widgets.data.owcolor.AttrDesc`)
- [ ] test_oweditdomain (references OWColor)
- [x] test_owfeaturestatistics (saves np.ndarray, fixed in https://github.com/biolab/orange3/pull/4375)
- [ ] test_owpivot (saves enum)
- [ ] test_owpreprocess (saves enum)
- [ ] test_owpythonscript (saves `Orange.widgets.data.owpythonscript.Script`)
- [x] test_owrank (fixed by https://github.com/biolab/orange3/pull/4315)
- [ ] test_report (saves enum)
- [ ] test_owdistancemap (saves range)
- [ ] test_owboxplot (saves `Orange.data.filter.Values`)
- [ ] test_owfile (saves `RecentPath`, but it does not fail, because parent `tearDown` is not invoked)



##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
