### PR TITLE
[ENH] Refactor statusbar, prettify

### DIFF
--- a/orangewidget/utils/messagewidget.py
+++ b/orangewidget/utils/messagewidget.py
@@ -356,7 +356,7 @@ class MessagesWidget(QWidget):
         self.setLayout(QHBoxLayout())
         self.layout().setContentsMargins(2, 1, 2, 1)
         self.layout().setSpacing(0)
-        self.layout().addWidget(self.__iconwidget)
+        self.layout().addWidget(self.__iconwidget, alignment=Qt.AlignLeft)
         self.layout().addSpacing(4)
         self.layout().addWidget(self.__textlabel)
         self.layout().addWidget(self.__popupicon)
@@ -369,7 +369,7 @@ class MessagesWidget(QWidget):
         self.anim.setKeyValueAt(0.5, 0)
         self.anim.setEndValue(1)
         self.anim.setEasingCurve(QEasingCurve.OutQuad)
-        self.anim.setLoopCount(5)
+        self.anim.setLoopCount(2)
 
     def sizeHint(self):
         sh = super().sizeHint()
@@ -528,7 +528,6 @@ class MessagesWidget(QWidget):
         icon = message_icon(summary)
         self.__iconwidget.setIcon(icon)
         self.__iconwidget.setVisible(not (summary.isEmpty() or icon.isNull()))
-        self.anim.start(QPropertyAnimation.KeepWhenStopped)
         self.__textlabel.setTextFormat(summary.textFormat)
         self.__textlabel.setText(summary.text)
         self.__textlabel.setVisible(bool(summary.text))
@@ -541,6 +540,7 @@ class MessagesWidget(QWidget):
             fulltext = ""
         self.__fulltext = fulltext
         self.setToolTip(self.__styled(self.__defaultStyleSheet, fulltext))
+        self.anim.start(QPropertyAnimation.KeepWhenStopped)
 
         def is_short(m):
             return not (m.informativeText or m.detailedText)

--- a/orangewidget/utils/messagewidget.py
+++ b/orangewidget/utils/messagewidget.py
@@ -389,13 +389,6 @@ class MessagesWidget(QWidget):
             sizePolicy=QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Minimum),
             elide=elideText
         )
-        #: Indicator that extended contents are accessible with a click on the
-        #: widget.
-        self.__popupicon = QLabel(
-            sizePolicy=QSizePolicy(QSizePolicy.Maximum, QSizePolicy.Maximum),
-            text="\N{VERTICAL ELLIPSIS}",
-            visible=False,
-        )
         self.__textlabel.linkActivated.connect(self.linkActivated)
         self.__textlabel.linkHovered.connect(self.linkHovered)
         self.setLayout(QHBoxLayout())
@@ -404,7 +397,6 @@ class MessagesWidget(QWidget):
         self.layout().addWidget(self.__iconwidget, alignment=Qt.AlignLeft)
         self.layout().addSpacing(4)
         self.layout().addWidget(self.__textlabel)
-        self.layout().addWidget(self.__popupicon)
         self.__textlabel.setAttribute(Qt.WA_MacSmallSize)
         self.__defaultStyleSheet = defaultStyleSheet
 
@@ -594,7 +586,6 @@ class MessagesWidget(QWidget):
             self.__popuptext = ""
         else:
             self.__popuptext = fulltext
-        self.__popupicon.setVisible(bool(self.__popuptext))
         self.layout().activate()
 
     def mousePressEvent(self, event):
@@ -634,7 +625,7 @@ class MessagesWidget(QWidget):
     def paintEvent(self, event):
         opt = QStyleOption()
         opt.initFrom(self)
-        if not self.__popupicon.isVisible():
+        if not self.__popuptext:
             return
 
         if not (opt.state & QStyle.State_MouseOver or

--- a/orangewidget/utils/messagewidget.py
+++ b/orangewidget/utils/messagewidget.py
@@ -596,6 +596,7 @@ class MessagesWidget(QWidget):
                     self, textInteractionFlags=Qt.TextBrowserInteraction,
                     openExternalLinks=self.__openExternalLinks,
                 )
+                label.setContentsMargins(4, 4, 4, 4)
                 label.setText(self.__styled(self.__defaultStyleSheet,
                                             self.__popuptext))
 

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -11,8 +11,8 @@ from typing import Optional, Union
 from AnyQt.QtWidgets import (
     QWidget, QDialog, QVBoxLayout, QSizePolicy, QApplication, QStyle,
     QShortcut, QSplitter, QSplitterHandle, QPushButton, QStatusBar,
-    QProgressBar, QAction, QFrame, QStyleOption, QWIDGETSIZE_MAX
-)
+    QProgressBar, QAction, QFrame, QStyleOption, QWIDGETSIZE_MAX,
+    QHBoxLayout)
 from AnyQt.QtCore import (
     Qt, QObject, QEvent, QRect, QMargins, QByteArray, QDataStream, QBuffer,
     QSettings, QUrl, QThread, pyqtSignal as Signal, QSize)
@@ -474,6 +474,11 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
         if self.want_message_bar:
             sb = self.statusBar()
+
+            buttonsLayout = QHBoxLayout()
+            buttonsLayout.setContentsMargins(7, 0, 0, 0)
+            buttonsLayout.setSpacing(5)
+
             help = self.__help_action
             icon = QIcon(gui.resource_filename("icons/help.svg"))
             icon.addFile(gui.resource_filename("icons/help-hover.svg"), mode=QIcon.Active)
@@ -486,7 +491,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                 help_button.setVisible(help.isVisible())
                 help_button.setEnabled(help.isEnabled())
             help_button.clicked.connect(help.trigger)
-            sb.addWidget(help_button)
+            buttonsLayout.addWidget(help_button)
 
             if self.graph_name is not None:
                 icon = QIcon(gui.resource_filename("icons/chart.svg"))
@@ -496,7 +501,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                     toolTip="Save Image",
                 )
                 b.clicked.connect(self.save_graph)
-                sb.addWidget(b)
+                buttonsLayout.addWidget(b)
             if hasattr(self, "send_report"):
                 icon = QIcon(gui.resource_filename("icons/report.svg"))
                 icon.addFile(gui.resource_filename("icons/report-hover.svg"), mode=QIcon.Active)
@@ -505,7 +510,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                     toolTip="Report"
                 )
                 b.clicked.connect(self.show_report)
-                sb.addWidget(b)
+                buttonsLayout.addWidget(b)
             if hasattr(self, "reset_settings"):
                 icon = QIcon(gui.resource_filename("icons/reset.svg"))
                 icon.addFile(gui.resource_filename("icons/reset-hover.svg"), mode=QIcon.Active)
@@ -514,7 +519,19 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                     toolTip="Reset settings to defaults"
                 )
                 b.clicked.connect(self.reset_settings)
-                sb.addWidget(b)
+                buttonsLayout.addWidget(b)
+
+            buttons = QWidget(objectName="buttons")
+            buttons.setLayout(buttonsLayout)
+            sb.addWidget(buttons)
+
+            in_out_msg = QWidget(objectName="in-out-msg")
+            in_out_msg.setLayout(QHBoxLayout())
+            in_out_msg.layout().setContentsMargins(5, 0, 0, 0)
+            in_out_msg.layout().setSpacing(5)
+            in_out_msg.setVisible(False)
+            sb.addWidget(in_out_msg)
+
             self.message_bar = MessagesWidget(
                 defaultStyleSheet=textwrap.dedent("""
                 div.field-text {
@@ -647,12 +664,19 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                     sizePolicy=QSizePolicy(QSizePolicy.Preferred,
                                            QSizePolicy.Preferred)
                 )
+
+                in_out_msg = sb.findChild(QWidget, "in-out-msg")
+
                 # Insert a separator if these are not the first elements
-                # TODO: This needs a better check.
-                if sb.findChildren(SimpleButton):
-                    sb.addWidget(QFrame(frameShape=QFrame.VLine))
-                sb.addWidget(in_msg)
-                sb.addWidget(out_msg)
+                buttons = sb.findChild(QWidget, "buttons")
+                if buttons.layout().count() != 0:
+                    sep = QFrame(frameShape=QFrame.VLine)
+                    sep.setContentsMargins(0, 0, 2, 0)
+                    in_out_msg.layout().addWidget(sep)
+
+                in_out_msg.layout().addWidget(in_msg)
+                in_out_msg.layout().addWidget(out_msg)
+                in_out_msg.setVisible(True)
 
                 def set_message(msgwidget, m):
                     # type: (MessagesWidget, StateInfo.Summary) -> None

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -1619,6 +1619,8 @@ class StateInfo(QObject):
             summary = StateInfo.Summary()
         elif isinstance(summary, StateInfo.Summary):
             assert_single_arg()
+            if isinstance(summary, StateInfo.Empty):
+                summary = summary.updated(details="No data on input")
             if summary.icon.isNull():
                 summary = summary.updated(icon=summary.default_icon("input"))
         elif isinstance(summary, str):
@@ -1674,6 +1676,8 @@ class StateInfo(QObject):
             summary = StateInfo.Summary()
         elif isinstance(summary, StateInfo.Summary):
             assert_single_arg()
+            if isinstance(summary, StateInfo.Empty):
+                summary = summary.updated(details="No data on output")
             if summary.icon.isNull():
                 summary = summary.updated(icon=summary.default_icon("output"))
         elif isinstance(summary, str):

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -475,63 +475,6 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         if self.want_message_bar:
             sb = self.statusBar()
 
-            buttonsLayout = QHBoxLayout()
-            buttonsLayout.setContentsMargins(7, 0, 0, 0)
-            buttonsLayout.setSpacing(5)
-
-            help = self.__help_action
-            icon = QIcon(gui.resource_filename("icons/help.svg"))
-            icon.addFile(gui.resource_filename("icons/help-hover.svg"), mode=QIcon.Active)
-            help_button = SimpleButton(
-                icon=icon,
-                toolTip="Show widget help", visible=help.isVisible(),
-            )
-            @help.changed.connect
-            def _():
-                help_button.setVisible(help.isVisible())
-                help_button.setEnabled(help.isEnabled())
-            help_button.clicked.connect(help.trigger)
-            buttonsLayout.addWidget(help_button)
-
-            if self.graph_name is not None:
-                icon = QIcon(gui.resource_filename("icons/chart.svg"))
-                icon.addFile(gui.resource_filename("icons/chart-hover.svg"), mode=QIcon.Active)
-                b = SimpleButton(
-                    icon=icon,
-                    toolTip="Save Image",
-                )
-                b.clicked.connect(self.save_graph)
-                buttonsLayout.addWidget(b)
-            if hasattr(self, "send_report"):
-                icon = QIcon(gui.resource_filename("icons/report.svg"))
-                icon.addFile(gui.resource_filename("icons/report-hover.svg"), mode=QIcon.Active)
-                b = SimpleButton(
-                    icon=icon,
-                    toolTip="Report"
-                )
-                b.clicked.connect(self.show_report)
-                buttonsLayout.addWidget(b)
-            if hasattr(self, "reset_settings"):
-                icon = QIcon(gui.resource_filename("icons/reset.svg"))
-                icon.addFile(gui.resource_filename("icons/reset-hover.svg"), mode=QIcon.Active)
-                b = SimpleButton(
-                    icon=icon,
-                    toolTip="Reset settings to defaults"
-                )
-                b.clicked.connect(self.reset_settings)
-                buttonsLayout.addWidget(b)
-
-            buttons = QWidget(objectName="buttons")
-            buttons.setLayout(buttonsLayout)
-            sb.addWidget(buttons)
-
-            in_out_msg = QWidget(objectName="in-out-msg")
-            in_out_msg.setLayout(QHBoxLayout())
-            in_out_msg.layout().setContentsMargins(5, 0, 0, 0)
-            in_out_msg.layout().setSpacing(5)
-            in_out_msg.setVisible(False)
-            sb.addWidget(in_out_msg)
-
             self.message_bar = MessagesWidget(
                 defaultStyleSheet=textwrap.dedent("""
                 div.field-text {
@@ -615,6 +558,66 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             )
             statusbar_action.toggled[bool].connect(statusbar.setVisible)
             self.addAction(statusbar_action)
+
+            # Create buttons
+            buttonsLayout = QHBoxLayout()
+            buttonsLayout.setContentsMargins(7, 0, 0, 0)
+            buttonsLayout.setSpacing(5)
+
+            help = self.__help_action
+            icon = QIcon(gui.resource_filename("icons/help.svg"))
+            icon.addFile(gui.resource_filename("icons/help-hover.svg"), mode=QIcon.Active)
+            help_button = SimpleButton(
+                icon=icon,
+                toolTip="Show widget help", visible=help.isVisible(),
+            )
+
+            @help.changed.connect
+            def _():
+                help_button.setVisible(help.isVisible())
+                help_button.setEnabled(help.isEnabled())
+
+            help_button.clicked.connect(help.trigger)
+            buttonsLayout.addWidget(help_button)
+
+            if self.graph_name is not None:
+                icon = QIcon(gui.resource_filename("icons/chart.svg"))
+                icon.addFile(gui.resource_filename("icons/chart-hover.svg"), mode=QIcon.Active)
+                b = SimpleButton(
+                    icon=icon,
+                    toolTip="Save Image",
+                )
+                b.clicked.connect(self.save_graph)
+                buttonsLayout.addWidget(b)
+            if hasattr(self, "send_report"):
+                icon = QIcon(gui.resource_filename("icons/report.svg"))
+                icon.addFile(gui.resource_filename("icons/report-hover.svg"), mode=QIcon.Active)
+                b = SimpleButton(
+                    icon=icon,
+                    toolTip="Report"
+                )
+                b.clicked.connect(self.show_report)
+                buttonsLayout.addWidget(b)
+            if hasattr(self, "reset_settings"):
+                icon = QIcon(gui.resource_filename("icons/reset.svg"))
+                icon.addFile(gui.resource_filename("icons/reset-hover.svg"), mode=QIcon.Active)
+                b = SimpleButton(
+                    icon=icon,
+                    toolTip="Reset settings to defaults"
+                )
+                b.clicked.connect(self.reset_settings)
+                buttonsLayout.addWidget(b)
+
+            buttons = QWidget(objectName="buttons")
+            buttons.setLayout(buttonsLayout)
+            statusbar.addWidget(buttons)
+
+            in_out_msg = QWidget(objectName="in-out-msg")
+            in_out_msg.setLayout(QHBoxLayout())
+            in_out_msg.layout().setContentsMargins(5, 0, 0, 0)
+            in_out_msg.layout().setSpacing(5)
+            in_out_msg.setVisible(False)
+            statusbar.addWidget(in_out_msg)
         return statusbar
 
     def __updateStatusBarOnChange(self):

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -542,7 +542,8 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                     margin-bottom: 0.5em;
                     margin-left: 1em;
                     margin-right: 1em;
-                }""")
+                }"""),
+                elideText=True
             )
             self.message_bar.setSizePolicy(QSizePolicy.Preferred,
                                            QSizePolicy.Preferred)

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -587,7 +587,13 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                 c, objectName="owwidget-status-bar"
             )
             statusbar.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Maximum)
-            statusbar.setSizeGripEnabled(self.resizing_enabled)
+
+            if self.resizing_enabled:
+                statusbar.setSizeGripEnabled(True)
+            else:
+                statusbar.setSizeGripEnabled(False)
+                statusbar.setContentsMargins(0, 0, 7, 0)
+
             statusbar.ensurePolished()
             c.layout().addWidget(statusbar)
 

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -662,14 +662,14 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                 in_msg = MessagesWidget(
                     objectName="input-summary", visible=False,
                     defaultStyleSheet=css,
-                    sizePolicy=QSizePolicy(QSizePolicy.Preferred,
-                                           QSizePolicy.Preferred)
+                    sizePolicy=QSizePolicy(QSizePolicy.Fixed,
+                                           QSizePolicy.Fixed)
                 )
                 out_msg = MessagesWidget(
                     objectName="output-summary", visible=False,
                     defaultStyleSheet=css,
-                    sizePolicy=QSizePolicy(QSizePolicy.Preferred,
-                                           QSizePolicy.Preferred)
+                    sizePolicy=QSizePolicy(QSizePolicy.Fixed,
+                                           QSizePolicy.Fixed)
                 )
 
                 in_out_msg = sb.findChild(QWidget, "in-out-msg")


### PR DESCRIPTION
(edited 11th Feb)
##### Description of changes
- Played around with content margins
- Elide warning/error message
- Fix in/out message size
- Remove in/out message size grip
- In/out messages always have a popup
- Remove first line from popup/tooltip

Before:

![statusbar-before](https://user-images.githubusercontent.com/24586651/74244982-31c81880-4cda-11ea-8b04-4ae27c43dfbb.gif)

After:

![statusbar-after](https://user-images.githubusercontent.com/24586651/74244993-34c30900-4cda-11ea-8557-35ec7d546493.gif)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
