### PR TITLE
[FIX] Tests cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ matrix:
       env:
         - TEST_DEP="PyQt5~=5.12.1 PyQtWebEngine~=5.12.1"
 
+    - python: '3.8'
+      env:
+        - TEST_DEP="PyQt5~=5.14.0 PyQtWebEngine~=5.14.0"
+
 cache:
   pip: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - PIP_DISABLE_PIP_VERSION_CHECK=1
     - XVFBARGS="-screen 0 1280x1024x24"
-    - BUILD_DEP="pip~=19.0.0 wheel"
+    - BUILD_DEP="pip~=19.3.1 wheel"
     - TEST_DEP="PyQt5~=5.9.2"
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,10 @@ environment:
     - PYTHON: C:\Python37-x64
       TEST_DEP: PyQt5~=5.12.1 PyQtWebEngine~=5.12.1
 
+    - PYTHON: C:\Python38-x64
+      TEST_DEP: PyQt5~=5.14.0 PyQtWebEngine~=5.14.0
+
+
 cache:
   - '%LOCALAPPDATA%\pip\cache -> appveyor.yml'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
   global:
     PROJECT_NAME: "orange-widget-base"
     PIP_DISABLE_PIP_VERSION_CHECK: "1"
-    BUILD_DEP: wheel==0.29.0 pip~=19.0.0
+    BUILD_DEP: wheel==0.29.0 pip~=19.3.1
     TEST_DEP: PyQt5~=5.9.2
 
   matrix:
@@ -46,7 +46,7 @@ test_script:
   - build\.test\Scripts\activate
   - cd build\.test
   # Pre-populate the test environment
-  - python -m pip install pip~=19.0.0 wheel
+  - python -m pip install pip~=19.3 wheel
 
   - python -m pip install %TEST_DEP%
   - python -m pip install --no-index --no-deps -f ..\..\dist --pre %PROJECT_NAME%==%VERSION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ environment:
       TEST_DEP: PyQt5~=5.12.1 PyQtWebEngine~=5.12.1
 
     - PYTHON: C:\Python38-x64
-      TEST_DEP: PyQt5~=5.14.0 PyQtWebEngine~=5.14.0
+      TEST_DEP: "PyQt5~=5.14.0 PyQtWebEngine~=5.14.0 \"pyqtgraph>=0.11a0\""
 
 
 cache:

--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -210,6 +210,11 @@ class WidgetTest(GuiTest):
         if not (os.environ.get("TRAVIS") or os.environ.get("APPVEYOR")):
             report.show = Mock()
 
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+        cls.widgets.clear()
+
     def tearDown(self):
         """Process any pending events before the next test is executed."""
         self.process_events()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Running tests with Qt 5.14 prints warning on exit:

```
Release of profile requested but WebEnginePage still not deleted. Expect troubles !
```

See also https://github.com/biolab/orange3/pull/4284

##### Description of changes

* Remove references from global `WidgetTest.widget` list.
* Add PyQt5 5.14 to test matrix


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
