### PR TITLE
[FIX] io: Set svg generator's resolution to match the default screen

### DIFF
--- a/orangewidget/io.py
+++ b/orangewidget/io.py
@@ -194,6 +194,7 @@ class SvgFormat(ImgFormat):
     @staticmethod
     def _get_buffer(size, filename):
         buffer = QtSvg.QSvgGenerator()
+        buffer.setResolution(QApplication.desktop().logicalDpiX())
         buffer.setFileName(filename)
         buffer.setSize(QtCore.QSize(int(size.width()), int(size.height())))
         return buffer


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Exporting a QPicture to SVG can result in wring scale of the exported picture.
This happens when the default screen DPI does not match that of the paint device ([QTBUG-20361](https://bugreports.qt.io/browse/QTBUG-20361))

Examples where this happens: 'Hierarchical clustering', 'Silhouette plot' in Orange3 on Windows, Linux systems were default DPI is 96 (so probably most systems).

##### Description of changes

* Set svg generator's resolution to match the default screen DPI

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
