### PR TITLE
gui.comboBox: Fix unassigned local variable

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -1450,6 +1450,7 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
         length (default: 25, use 0 to disable)
     :rtype: QComboBox
     """
+    widget_label = None
     if box or label:
         hb = widgetBox(widget, box, orientation, addToLayout=False)
         if label is not None:


### PR DESCRIPTION
`widget_label` was sometimes unassigned before use.

This didn't bite us because Orange uses a separate definition of `comboBox` (and will until https://github.com/biolab/orange3/pull/4158), but would bite anybody who used orange-widget-base separately.