### PR TITLE
[ENH] StateInfo: Allow details along with int summary

### DIFF
--- a/orangewidget/tests/test_widget.py
+++ b/orangewidget/tests/test_widget.py
@@ -3,6 +3,7 @@
 import gc
 import weakref
 
+import unittest
 from unittest.mock import patch, MagicMock
 
 from AnyQt.QtCore import Qt, QPoint, QRect, QByteArray, QObject, pyqtSignal
@@ -463,8 +464,13 @@ class WidgetTestInfoSummary(WidgetTest):
         with self.assertRaises(TypeError):
             info.set_output_summary(info.NoOutput, "a")
 
-        with self.assertRaises(TypeError):
-            info.set_output_summary(1234, "a")
+        info.set_input_summary(1234, "Foo")
+        info.set_output_summary(1234, "Bar")
+
+        self.assertEqual(inmsg.summarize().text, "1234")
+        self.assertEqual(inmsg.summarize().informativeText, "Foo")
+        self.assertEqual(outmsg.summarize().text, "1234")
+        self.assertEqual(outmsg.summarize().informativeText, "Bar")
 
     def test_format_number(self):
         self.assertEqual(StateInfo.format_number(9999), "9999")
@@ -475,3 +481,7 @@ class WidgetTestInfoSummary(WidgetTest):
         self.assertEqual(StateInfo.format_number(1_234_567), "1.23M")
         self.assertEqual(StateInfo.format_number(999_999), "1M")
         self.assertEqual(StateInfo.format_number(1_000_000), "1M")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -1595,9 +1595,9 @@ class StateInfo(QObject):
             if summary.icon.isNull():
                 summary = summary.updated(icon=summary.default_icon("input"))
         elif isinstance(summary, int):
-            assert_single_arg()
             formatted_summary = self.format_number(summary)
-            summary = StateInfo.Summary(formatted_summary, str(summary),
+            summary = StateInfo.Summary(formatted_summary,
+                                        details or str(summary),
                                         StateInfo.Summary.default_icon("input"))
         else:
             raise TypeError("'None', 'str' or 'Message' instance expected, "
@@ -1650,9 +1650,9 @@ class StateInfo(QObject):
             if summary.icon.isNull():
                 summary = summary.updated(icon=summary.default_icon("output"))
         elif isinstance(summary, int):
-            assert_single_arg()
             formatted_summary = self.format_number(summary)
-            summary = StateInfo.Summary(formatted_summary, str(summary),
+            summary = StateInfo.Summary(formatted_summary,
+                                        details or str(summary),
                                         StateInfo.Summary.default_icon("output"))
         else:
             raise TypeError("'None', 'str' or 'Message' instance expected, "


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When setting input/output summary with an integer value, allow setting the details as well.

##### Description of changes
- remove single arg check
- use summary as default detail

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
