### PR TITLE
SVGFormat: Insert 'nonpixelated' into svg style

### DIFF
--- a/orangewidget/io.py
+++ b/orangewidget/io.py
@@ -219,16 +219,20 @@ class SvgFormat(ImgFormat):
     def write_image(cls, filename, scene):
         # WebviewWidget exposes its SVG contents more directly;
         # no need to go via QPainter if we can avoid it
+        svg = None
         if WebviewWidget is not None and isinstance(scene, WebviewWidget):
             try:
                 svg = scene.svg()
-                with open(filename, 'w') as f:
-                    f.write(svg)
-                return
             except (ValueError, IOError):
                 pass
-
-        super().write_image(filename, scene)
+        if svg is None:
+            super().write_image(filename, scene)
+            svg = open(filename).read()
+        svg = svg.replace(
+            "<svg ",
+            '<svg style="image-rendering:optimizeSpeed;image-rendering:pixelated" ')
+        with open(filename, 'w') as f:
+            f.write(svg)
 
 
 class MatplotlibFormat:


### PR DESCRIPTION
##### Issue

Fixes #45.

Browsers (and Inkscape) blur svg files. The solution is to insert `style="image-rendering:optimizeSpeed;image-rendering:pixelated"`, but this is apparently impossible because SVG headers in Qt are hard-coded: https://github.com/qt/qtsvg/blob/4cdd71fd2070e439ef7daa8f932f19f76020a45b/src/svg/qsvggenerator.cpp#L896.

##### Description of changes

Would I lose all respect I might perhaps enjoy if I proposed this patch?

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
