### PR TITLE
Added search option to comboBox

### DIFF
--- a/orangewidget/utils/tests/test_combobox.py
+++ b/orangewidget/utils/tests/test_combobox.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+import pkg_resources
 from AnyQt.QtCore import Qt, QRect
 from AnyQt.QtWidgets import QListView, QApplication
 from AnyQt.QtTest import QTest, QSignalSpy
@@ -133,3 +134,14 @@ class TestComboBoxSearch(GuiTest):
             geom, QRect(0, 500, 100, 20), screen
         )
         self.assertEqual(g4, QRect(0, 500 - 400, 100, 400))
+
+    def test_deprecation(self):
+        """
+        When this test fails remove maximumContentsLength. Also remove
+        maximumContentsLength from gui.comboBox
+        """
+        version = pkg_resources.get_distribution("orange-widget-base").version
+        self.assertLess(
+            version, "4.6.0",
+            "Remove maximumContentsLength from ComboBox class and this test."
+        )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
ComboBoxSearch implemented but not included in comboBox fuction.
ComboBoxSearch does not implement maximumContentsLenght, which is implemented in ComboBox.

##### Description of changes
- Adding a searchable attribute to comboBox function - when True ComboBoxSearch used instead of ComboBox
- Deprecating maximumContentsLenght for ComboBox - reason not really used in practice 
- Setting maximumContentsLenght to the default value of 25.
- Implementing the same behavior for ComboBoxSearch (default max width 25).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
