### PR TITLE
[FIX] SvgFormat: Set 'viewBox' instead of 'size' to initiate the svg viewport

### DIFF
--- a/orangewidget/io.py
+++ b/orangewidget/io.py
@@ -196,7 +196,7 @@ class SvgFormat(ImgFormat):
         buffer = QtSvg.QSvgGenerator()
         buffer.setResolution(QApplication.desktop().logicalDpiX())
         buffer.setFileName(filename)
-        buffer.setSize(QtCore.QSize(int(size.width()), int(size.height())))
+        buffer.setViewBox(QtCore.QRectF(0, 0, size.width(), size.height()))
         return buffer
 
     @staticmethod


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

QSvgGenerator emits width and height in mm units, while the exported
geometry is unitless. 'viewBox' is emitted unitless and matches the
geometry.

##### Description of changes

Use `QSvgGenerator.viewBox` instead of `QSvgGenerator.size` to set exported svg viewport

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
