### PR TITLE
WidgetTest.get_output: Fix for unbound signals

### DIFF
--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -456,7 +456,9 @@ class WidgetTest(GuiTest):
         The last sent value of given output or None if nothing has been sent.
         """
         if widget is None:
-            widget = getattr(output, "widget", self.widget)
+            # `output` may be an unbound signal with `widget` set to `None`
+            # In this case, we use `self.widget`.
+            widget = getattr(output, "widget") or self.widget
 
         if not isinstance(output, str):
             output = output.name


### PR DESCRIPTION
##### Issue

When calling, say `self.get_output(OWContinuize.Outputs.data)` (as opposed to the more usual `self.get_output(self.widget.Outputs.data)`), the widget was retrieved through `getattr(output, "widget", self.widget)`. This however didn't work because `OWContinuize.Outputs.data` is an unbound signal, and unbound signals *do have* an attribute `widget`, but it's set to `None`. 

##### Description of changes

`getattr(obj, attr) or default` is equivalent to `getattr(obj, attr, default)`, except when ``getattr(obj, attr)` is `None` (it cannot be false in another way here) - which is what we need.

##### Includes
- [X] Code changes