### PR TITLE
[FIX] WidgetTest: Handle string parameter when invoking get_output()

### DIFF
--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -458,7 +458,7 @@ class WidgetTest(GuiTest):
         if widget is None:
             # `output` may be an unbound signal with `widget` set to `None`
             # In this case, we use `self.widget`.
-            widget = getattr(output, "widget") or self.widget
+            widget = getattr(output, "widget", self.widget) or self.widget
 
         if not isinstance(output, str):
             output = output.name


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #50

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
