### PR TITLE
Change version when maximumContentsLength removed to higher

### DIFF
--- a/orangewidget/utils/tests/test_combobox.py
+++ b/orangewidget/utils/tests/test_combobox.py
@@ -142,6 +142,6 @@ class TestComboBoxSearch(GuiTest):
         """
         version = pkg_resources.get_distribution("orange-widget-base").version
         self.assertLess(
-            version, "4.6.0",
+            version, "4.7.0",
             "Remove maximumContentsLength from ComboBox class and this test."
         )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Version when `maximumContentsLength` need to be removed is to low

##### Description of changes
It so it is moved to the next version.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
