### PR TITLE
[FIX] open_filename_dialog: Fix empty filter returned from QFileDialog.getOpenFileName

### DIFF
--- a/orangewidget/utils/filedialogs.py
+++ b/orangewidget/utils/filedialogs.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import typing
+from fnmatch import fnmatch
 from typing import Tuple
 
 from AnyQt.QtCore import QFileInfo, Qt
@@ -121,7 +122,7 @@ def open_filename_dialog_save(start_dir, start_filter, file_formats):
         return filename, format, filter
 
 
-def open_filename_dialog(start_dir, start_filter, file_formats,
+def open_filename_dialog(start_dir: str, start_filter: str, file_formats,
                          add_all=True, title="Open...", dialog=None):
     """
     Open file dialog with file formats.
@@ -161,7 +162,22 @@ def open_filename_dialog(start_dir, start_filter, file_formats,
     if not filename:
         return None, None, None
 
-    file_format = file_formats[filters.index(filter)]
+    if filter and not (add_all and filter == filters[0]):
+        file_format = file_formats[filters.index(filter)]
+    else:
+        base = os.path.basename(filename)
+        for file_format in file_formats[add_all:]:
+            if any(fnmatch(base, '*' + ext)
+                   for ext in file_format.EXTENSIONS
+                   # Skip ambiguous compression-only extensions added on OSX
+                   if ext not in Compression.all):
+                break
+        else:
+            # This shouldn't happen, but if it does, returning the first
+            # filter is the best we can do. Let the reader fail then.
+            file_format = file_formats[1 if add_all else 0]
+        filter = format_filter(file_format)
+
     return filename, file_format, filter
 
 

--- a/orangewidget/utils/tests/test_filedialogs.py
+++ b/orangewidget/utils/tests/test_filedialogs.py
@@ -1,8 +1,9 @@
 import os
 import unittest
+from unittest.mock import Mock
 from tempfile import NamedTemporaryFile
 
-from orangewidget.utils.filedialogs import RecentPath
+from orangewidget.utils.filedialogs import RecentPath, open_filename_dialog
 
 
 class TestRecentPath(unittest.TestCase):
@@ -20,3 +21,67 @@ class TestRecentPath(unittest.TestCase):
             self.assertIsNotNone(recent_path.resolve(search_paths))
         finally:
             os.remove(file_name)
+
+
+class TestOpenFilenameDialog(unittest.TestCase):
+    def test_empty_filter(self):
+        class XYZFormat:
+            EXTENSIONS = ('.xyz',)
+            DESCRIPTION = 'xyz file'
+            PRIORITY = 20
+
+        class XYZGZFormat:
+            EXTENSIONS = ('.xyz.gz',)
+            DESCRIPTION = 'Compressed xyz file'
+            PRIORITY = 20
+
+        class ABCFormat:
+            EXTENSIONS = ('.abc', '.jkl')
+            DESCRIPTION = 'abc file'
+            PRIORITY = 30
+
+        name, file_format, file_filter = open_filename_dialog(
+            ".", "", [ABCFormat, XYZFormat],
+            dialog=Mock(return_value=("foo.xyz", "")))
+        self.assertEqual(name, "foo.xyz")
+        self.assertEqual(file_format, XYZFormat)
+        self.assertEqual(file_filter, "xyz file (*.xyz)")
+
+        name, file_format, file_filter = open_filename_dialog(
+            ".", "", [ABCFormat, XYZFormat, XYZGZFormat],
+            dialog=Mock(return_value=("foo.xyz.gz", "")))
+        self.assertEqual(name, "foo.xyz.gz")
+        self.assertEqual(file_format, XYZGZFormat)
+        self.assertEqual(file_filter, "Compressed xyz file (*.xyz.gz)")
+
+        name, file_format, file_filter = open_filename_dialog(
+            ".", "", [ABCFormat, XYZFormat],
+            dialog=Mock(return_value=("foo.abc", "")))
+        self.assertEqual(name, "foo.abc")
+        self.assertEqual(file_format, ABCFormat)
+        self.assertEqual(file_filter, "abc file (*.abc *.jkl)")
+
+        name, file_format, file_filter = open_filename_dialog(
+            ".", "", [ABCFormat, XYZFormat],
+            dialog=Mock(return_value=("foo.jkl", "")))
+        self.assertEqual(name, "foo.jkl")
+        self.assertEqual(file_format, ABCFormat)
+        self.assertEqual(file_filter, "abc file (*.abc *.jkl)")
+
+        name, file_format, file_filter = open_filename_dialog(
+            ".", "", [ABCFormat, XYZFormat],
+            dialog=Mock(return_value=("foo.def", "")))
+        self.assertEqual(name, "foo.def")
+        self.assertEqual(file_format, XYZFormat)
+        self.assertEqual(file_filter, "xyz file (*.xyz)")
+
+        name, file_format, file_filter = open_filename_dialog(
+            ".", "", [ABCFormat, XYZFormat],
+            dialog=Mock(return_value=("foo.def", "")), add_all=False)
+        self.assertEqual(name, "foo.def")
+        self.assertEqual(file_format, XYZFormat)
+        self.assertEqual(file_filter, "xyz file (*.xyz)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

https://github.com/biolab/orange3/issues/4537: `getOpenFileName` sometimes returns an empty filter. We can't reproduce the problem, so this is a blind fix, with a test.

##### Includes
- [X] Code changes
- [X] Tests