### PR TITLE
Searchable combo filter: Move popup below focus frame

### DIFF
--- a/orangewidget/utils/combobox.py
+++ b/orangewidget/utils/combobox.py
@@ -1,4 +1,4 @@
-import warnings
+import sys
 from typing import Optional
 
 from AnyQt.QtCore import (
@@ -238,6 +238,10 @@ class ComboBoxSearch(QComboBox):
         popuprect_origin = style.subControlRect(
             QStyle.CC_ComboBox, opt, QStyle.SC_ComboBoxListBoxPopup, self
         )  # type: QRect
+        if sys.platform == "darwin":
+            slmargin = self.__searchline.style() \
+                .pixelMetric(QStyle.PM_FocusFrameVMargin)
+            popuprect_origin.adjust(slmargin / 2, 0, -slmargin * 1.5, slmargin)
         popuprect_origin = QRect(
             self.mapToGlobal(popuprect_origin.topLeft()),
             popuprect_origin.size()


### PR DESCRIPTION
On (my) mac, the popup covers the border around the line edit, making it i-can't-watch-this ugly.

<img width="212" alt="Screenshot 2020-03-26 at 12 56 27" src="https://user-images.githubusercontent.com/2387315/77644534-6aa60f00-6f61-11ea-82b4-68e73e105fe0.png">

I think it should be shown a few pixels lower.

<img width="219" alt="Screenshot 2020-03-26 at 13 06 31" src="https://user-images.githubusercontent.com/2387315/77645203-a4c3e080-6f62-11ea-829c-a29e7bdaf7df.png">

How does this look on Linux and Windows?

A perhaps better alternative could be to not show the frame at all.