### PR TITLE
PyTableModel: Fix wrapping empty lists in constructor

### DIFF
--- a/orangewidget/utils/itemmodels.py
+++ b/orangewidget/utils/itemmodels.py
@@ -255,7 +255,9 @@ class PyTableModel(AbstractSortTableModel):
         self._editable = editable
         self._table = None
         self._roleData = None
-        self.wrap(sequence or [])
+        if sequence is None:
+            sequence = []
+        self.wrap(sequence)
 
     def rowCount(self, parent=QModelIndex()):
         return 0 if parent.isValid() else len(self)

--- a/orangewidget/utils/tests/test_itemmodels.py
+++ b/orangewidget/utils/tests/test_itemmodels.py
@@ -98,6 +98,14 @@ class TestPyTableModel(unittest.TestCase):
         self.assertEqual(self.model.rowCount(), 1)
         self.assertEqual(self.model.columnCount(), 1)
 
+    def test_init_wrap_empty(self):
+        # pylint: disable=protected-access
+        t = []
+        model = PyTableModel(t)
+        self.assertIs(model._table, t)
+        t.append([1, 2, 3])
+        self.assertEqual(list(model), [[1, 2, 3]])
+
     def test_clear(self):
         self.model.clear()
         self.assertEqual(self.model.rowCount(), 0)


### PR DESCRIPTION
See https://github.com/biolab/orange3/pull/4631. Same here.

##### Includes
- [X] Code changes
- [X] Tests
