### PR TITLE
ContextHandler.settings_to_widgets: pass *args to decode_setting

### DIFF
--- a/orangewidget/settings.py
+++ b/orangewidget/settings.py
@@ -931,7 +931,7 @@ class ContextHandler(SettingsHandler):
                 self.provider.traverse_settings(data=context.values, instance=widget):
             if not isinstance(setting, ContextSetting) or setting.name not in data:
                 continue
-            value = self.decode_setting(setting, data[setting.name])
+            value = self.decode_setting(setting, data[setting.name], *args)
             _apply_setting(setting, instance, value)
 
     def settings_from_widget(self, widget, *args):
@@ -978,7 +978,7 @@ class ContextHandler(SettingsHandler):
         """Encode value to be stored in settings dict"""
         return copy.copy(value)
 
-    def decode_setting(self, setting, value):
+    def decode_setting(self, setting, value, *args):
         """Decode settings value from the setting dict format"""
         return value
 


### PR DESCRIPTION
##### Issue

Any context handler that implements `open_context` with additional arguments (as probably all do!) currently has to redefine `settings_to_widget` solely to pass them do `decode_settings`. E.g. https://github.com/biolab/orange3/blob/master/Orange/widgets/settings.py#L143 differs from the inherited method just by the additional argument `domain`, which is passed to `decode_settings`.

##### Description of changes

This can be easily avoided by passing the existing `*args` to `decode_settings`. 

`ContextHandler.decode_setting` now accepts `*args` that will swallow any additional arguments, which `settings_to_widget` will now pass and which may not be expected by existing code.

`decode_setting` is currently redefined only in `DomainContextHandler` (which also redefines `settings_to_widget` accordingly), and in select rows, whose handler is derived from `DomainContextHandler`, so they both accept the extra argument provided in this PR.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
