### PR TITLE
[FIX] messagewidget: Give QPropertyAnimation a parent

### DIFF
--- a/orangewidget/utils/messagewidget.py
+++ b/orangewidget/utils/messagewidget.py
@@ -402,7 +402,8 @@ class MessagesWidget(QWidget):
         self.__textlabel.setAttribute(Qt.WA_MacSmallSize)
         self.__defaultStyleSheet = defaultStyleSheet
 
-        self.anim = QPropertyAnimation(self.__iconwidget, b"opacity")
+        self.anim = QPropertyAnimation(
+            self.__iconwidget, b"opacity", self.__iconwidget)
         self.anim.setDuration(350)
         self.anim.setStartValue(1)
         self.anim.setKeyValueAt(0.5, 0)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref: https://github.com/biolab/orange3/pull/4692#issuecomment-618867450, https://github.com/biolab/orange3/issues/4553#issuecomment-602530513, ..

##### Description of changes

Give QPropertyAnimation a parent so it is deleted at the same time as the widget.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
