### PR TITLE
[FIX] concurrent: Implement a workaround for QObject wrapper deletion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ install:
 
 script:
   - pip list --format=freeze
-  - xvfb-run -a -s "$XVFBARGS" python -m unittest discover -v -b .
+  - catchsegv xvfb-run -a -s "$XVFBARGS" python -m unittest discover -v -b .

--- a/orangewidget/utils/concurrent.py
+++ b/orangewidget/utils/concurrent.py
@@ -17,8 +17,50 @@ from AnyQt.QtCore import (
     QCoreApplication, QEvent, Q_ARG,
     pyqtSignal as Signal, pyqtSlot as Slot
 )
+import sip
 
 _log = logging.getLogger(__name__)
+
+
+class PyOwned:
+    """
+    A mixin for python owned QObject's used as queued cross thread
+    communication channels.
+
+    When this object is released from a thread that is not self.thread()
+    it is *resurrected* and scheduled for deferred deletion from its own
+    thread with self.deleteLater()
+    """
+    # This is a workaround for:
+    # https://www.riverbankcomputing.com/pipermail/pyqt/2020-April/042734.html
+    # Should not be necessary with PyQt5-sip>=12.8 (i.e sip api 12.8)
+    __delete_later_set = set()
+
+    def __del__(self: QObject):
+        # Note: This is otherwise quite similar to how PyQt5 does this except
+        # for the resurrection (i.e. the wrapper is allowed to be freed, but
+        # C++ part is deleteLater-ed).
+        if sip.ispyowned(self):
+            try:
+                own_thread = self.thread() is QThread.currentThread()
+            except RuntimeError:
+                return
+            if not own_thread:
+                # object resurrection; keep python wrapper alive and schedule
+                # deletion from the object's own thread.
+                PyOwned.__delete_later_set.add(self)
+                ref = weakref.ref(self)
+
+                # Clear final ref from 'destroyed' signal. As late as possible
+                # in QObject' destruction.
+                def clear():
+                    self = ref()
+                    try:
+                        PyOwned.__delete_later_set.remove(self)
+                    except KeyError:
+                        pass
+                self.destroyed.connect(clear, Qt.DirectConnection)
+                self.deleteLater()
 
 
 class FutureRunnable(QRunnable):
@@ -71,7 +113,7 @@ class FutureRunnable(QRunnable):
             log.critical("Exception in worker thread.", exc_info=True)
 
 
-class FutureWatcher(QObject):
+class FutureWatcher(QObject, PyOwned):
     """
     An `QObject` watching the state changes of a `concurrent.futures.Future`
 
@@ -235,7 +277,7 @@ class FutureWatcher(QObject):
         super().customEvent(event)
 
 
-class FutureSetWatcher(QObject):
+class FutureSetWatcher(QObject, PyOwned):
     """
     An `QObject` watching the state changes of a list of
     `concurrent.futures.Future` instances

--- a/orangewidget/utils/itemmodels.py
+++ b/orangewidget/utils/itemmodels.py
@@ -621,8 +621,11 @@ class PyListModel(QAbstractListModel):
 
     def extend(self, iterable):
         list_ = list(iterable)
+        count = len(list_)
+        if count == 0:
+            return
         self.beginInsertRows(QModelIndex(),
-                             len(self), len(self) + len(list_) - 1)
+                             len(self), len(self) + count - 1)
         self._list.extend(list_)
         self._other_data.extend([_store() for _ in list_])
         self.endInsertRows()
@@ -682,6 +685,8 @@ class PyListModel(QAbstractListModel):
     def __delitem__(self, s):
         if isinstance(s, slice):
             start, stop, _ = _as_contiguous_range(s, len(self))
+            if not len(self) or start == stop:
+                return
             self.beginRemoveRows(QModelIndex(), start, stop - 1)
         else:
             s = operator.index(s)
@@ -698,6 +703,8 @@ class PyListModel(QAbstractListModel):
 
             if not isinstance(value, list):
                 value = list(value)
+            if len(value) == 0:
+                return
             separators = [start + i for i, v in enumerate(value) if v is self.Separator]
             self.beginInsertRows(QModelIndex(), start, start + len(value) - 1)
             self._list[start:start] = value


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref: https://github.com/biolab/orange3/issues/4553

##### Description of changes

Implement a workaround for https://www.riverbankcomputing.com/pipermail/pyqt/2020-April/042734.html


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
