### PR TITLE
[FIX] ComboBoxSearch: Fix an AttributeError in hidePopup

### DIFF
--- a/orangewidget/utils/combobox.py
+++ b/orangewidget/utils/combobox.py
@@ -142,15 +142,16 @@ class ComboBoxSearch(QComboBox):
     """
     # NOTE: Setting editable + QComboBox.NoInsert policy + ... did not achieve
     # the same results.
-    def __init__(self, *args, **kwargs):
+    def __init__(self, parent=None, **kwargs):
         self.__maximumContentsLength = MAXIMUM_CONTENTS_LENGTH
-        super().__init__(*args, **kwargs)
-        self.__searchline = QLineEdit(self, visible=False, frame=False)
+        self.__searchline = QLineEdit(visible=False, frame=False)
         self.__searchline.setAttribute(Qt.WA_MacShowFocusRect, False)
-        self.__searchline.setFocusProxy(self)
         self.__popup = None  # type: Optional[QAbstractItemModel]
         self.__proxy = None  # type: Optional[QSortFilterProxyModel]
         self.__popupTimer = QElapsedTimer()
+        super().__init__(parent, **kwargs)
+        self.__searchline.setParent(self)
+        self.__searchline.setFocusProxy(self)
         self.setFocusPolicy(Qt.ClickFocus | Qt.TabFocus)
 
     def setMaximumContentsLength(self, length):  # type: (int) -> None

--- a/orangewidget/utils/tests/test_combobox.py
+++ b/orangewidget/utils/tests/test_combobox.py
@@ -7,7 +7,7 @@ from AnyQt.QtCore import Qt, QRect
 from AnyQt.QtWidgets import QListView, QApplication
 from AnyQt.QtTest import QTest, QSignalSpy
 from orangewidget.tests.base import GuiTest
-from orangewidget.tests.utils import mouseMove
+from orangewidget.tests.utils import mouseMove, excepthook_catch
 
 from orangewidget.utils import combobox
 
@@ -114,6 +114,12 @@ class TestComboBoxSearch(GuiTest):
         cb.showPopup()
         popup = cb.findChild(QListView)  # type: QListView
         self.assertIsNone(popup)
+
+    def test_kwargs_enabled_focus_out(self):
+        # PyQt5's property via kwargs can invoke virtual overrides while still
+        # not fully constructed
+        with excepthook_catch(raise_on_exit=True):
+            combobox.ComboBoxSearch(enabled=False)
 
     def test_popup_util(self):
         geom = QRect(10, 10, 100, 400)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

ComboBoxSearch(enabled=False) raised an:

```
Traceback (most recent call last):
  File "../orangewidget/utils/combobox.py", line 302, in hidePopup
    if self.__popup is not None:
AttributeError: 'ComboBoxSearch' object has no attribute '_ComboBoxSearch__popup'
```

Due to virtual override calls from within base QComboBox constructor

##### Description of changes

Reorder construction sequence

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
