### PR TITLE
Revert "[FIX] concurrent: Implement a workaround for QObject wrapper deletion"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ install:
 
 script:
   - pip list --format=freeze
-  - catchsegv xvfb-run -a -s "$XVFBARGS" python -m unittest discover -v -b .
+  - xvfb-run -a -s "$XVFBARGS" python -m unittest discover -v -b .

--- a/orangewidget/utils/itemmodels.py
+++ b/orangewidget/utils/itemmodels.py
@@ -621,11 +621,8 @@ class PyListModel(QAbstractListModel):
 
     def extend(self, iterable):
         list_ = list(iterable)
-        count = len(list_)
-        if count == 0:
-            return
         self.beginInsertRows(QModelIndex(),
-                             len(self), len(self) + count - 1)
+                             len(self), len(self) + len(list_) - 1)
         self._list.extend(list_)
         self._other_data.extend([_store() for _ in list_])
         self.endInsertRows()
@@ -685,8 +682,6 @@ class PyListModel(QAbstractListModel):
     def __delitem__(self, s):
         if isinstance(s, slice):
             start, stop, _ = _as_contiguous_range(s, len(self))
-            if not len(self) or start == stop:
-                return
             self.beginRemoveRows(QModelIndex(), start, stop - 1)
         else:
             s = operator.index(s)
@@ -703,8 +698,6 @@ class PyListModel(QAbstractListModel):
 
             if not isinstance(value, list):
                 value = list(value)
-            if len(value) == 0:
-                return
             separators = [start + i for i, v in enumerate(value) if v is self.Separator]
             self.beginInsertRows(QModelIndex(), start, start + len(value) - 1)
             self._list[start:start] = value

--- a/orangewidget/utils/tests/test_concurrent.py
+++ b/orangewidget/utils/tests/test_concurrent.py
@@ -2,20 +2,16 @@ import unittest
 import unittest.mock
 import threading
 import random
-import weakref
 
 from concurrent.futures import Future, ThreadPoolExecutor
 from types import SimpleNamespace
 from typing import Iterable, Set
 
-from AnyQt.QtCore import (
-    Qt, QObject, QCoreApplication, QThread, QEventLoop, QTimer, pyqtSlot,
-    pyqtSignal
-)
+from AnyQt.QtCore import QObject, QCoreApplication, QThread, pyqtSlot
 from AnyQt.QtTest import QSignalSpy
 
 from orangewidget.utils.concurrent import (
-    FutureWatcher, FutureSetWatcher, methodinvoke, PyOwned
+    FutureWatcher, FutureSetWatcher, methodinvoke
 )
 
 
@@ -220,75 +216,3 @@ class TestFutureSetWatcher(CoreAppTestCase):
         with unittest.mock.patch.object(watcher, "thread", lambda: 42), \
                 self.assertRaises(RuntimeError):
             watcher.flush()
-
-
-class TestPyOwned(CoreAppTestCase):
-    def test_py_owned(self):
-        class Obj(QObject, PyOwned):
-            pass
-
-        executor = ThreadPoolExecutor()
-        ref = SimpleNamespace(obj=Obj())
-        wref = weakref.ref(ref.obj)
-        event = threading.Event()
-        event.clear()
-
-        def clear_ref():
-            del ref.obj
-            event.set()
-
-        executor.submit(clear_ref)
-        event.wait()
-        self.assertIsNotNone(wref())
-        self.assertIn(wref(), PyOwned._PyOwned__delete_later_set)
-        loop = QEventLoop()
-        QTimer.singleShot(0, loop.quit)
-        loop.exec()
-        self.assertIsNone(wref())
-
-    def test_py_owned_enqueued(self):
-        # https://www.riverbankcomputing.com/pipermail/pyqt/2020-April/042734.html
-        class Emitter(QObject, PyOwned):
-            signal = pyqtSignal()
-            _p_signal = pyqtSignal()
-
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-                # queued signal -> signal connection
-                self._p_signal.connect(self.signal, Qt.QueuedConnection)
-
-            def schedule_emit(self):
-                """Schedule `signal` emit"""
-                self._p_signal.emit()
-
-        executor = ThreadPoolExecutor(max_workers=4)
-
-        def test_one():
-            ref = SimpleNamespace()  # hold single reference to Emitter obj
-            ref.obj = Emitter()
-            # enqueue 200 meta call events to the obj
-            for i in range(200):
-                ref.obj.schedule_emit()
-
-            # event signaling the event loop is about to be entered
-            event = threading.Event()
-
-            def clear_obj(ref=ref):
-                # wait for main thread to signal it is about to enter the event loop
-                event.wait()
-                del ref.obj  # clear the last/single ref to obj
-
-            executor.submit(clear_obj)
-
-            loop = QEventLoop()
-            QTimer.singleShot(0, loop.quit)
-            # bytecode optimizations, reduce the time between event.set and
-            # exec to minimum
-            set = event.set
-            exec = loop.exec
-
-            set()  # signal/unblock the worker;
-            exec()  # enter event loop to process the queued meta calls
-
-        for i in range(10):
-            test_one()


### PR DESCRIPTION
Reverts biolab/orange-widget-base#58

I merged it too early, and then noticed it produced crashes. @ales-erjavec, could you please reopen your pull request and note that it is WIP. :) Sorry, I was to eager to merge it before.