### PR TITLE
tests: Disable pyqtgraph exit cleanup handler

### DIFF
--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -2,6 +2,7 @@
 Testing framework for OWWidgets
 """
 import os
+import sys
 import tempfile
 
 import time
@@ -159,6 +160,14 @@ class GuiTest(unittest.TestCase):
         global app
         if app is None:
             app = QApplication([])
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if "pyqtgraph" in sys.modules:
+            import pyqtgraph
+            pyqtgraph.setConfigOption("exitCleanup", False)
+        super().tearDownClass()
 
 
 class WidgetTest(GuiTest):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Same as https://github.com/biolab/orange3/issues/2596 but for tests

Minimum reproducer:
```python
from PyQt5.QtWidgets import QApplication, QGraphicsScene
import pyqtgraph
app = QApplication([])
scene = QGraphicsScene()
group = scene.createItemGroup([])
scene.clear()
```
##### Description of changes

Disable pyqtgraph exit cleanup handler

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
