### PR TITLE
Typed and json-like-storable Settings

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -131,6 +131,16 @@ class OWComponent:
         self.controls = ControlGetter(self)
         if widget is not None and widget.settingsHandler:
             widget.settingsHandler.initialize(self)
+        else:
+            from orangewidget.settings import Setting
+            from orangewidget.widget import OWBaseWidget
+            if not isinstance(self, OWBaseWidget) \
+                    and any(isinstance(x, Setting)
+                            for x in type(self).__dict__.values()):
+                warnings.warn(
+                    f"{type(self).__name__} is initialized without a widget, "
+                    "so its settings will remain class attributes",
+                    stacklevel=2)
 
     def _reset_settings(self):
         """

--- a/orangewidget/settings.py
+++ b/orangewidget/settings.py
@@ -739,7 +739,10 @@ class SettingsHandler:
         if orig is tuple:
             return all(map(cls.is_allowed_type, args))
         if orig is dict:
-            return args[0] in (str, bool, int, float) \
+            # json.dumps will convert int and float into str, but we decode
+            # them back. We could allow bool, but it would complicate decoding
+            # and is not of much use anyway
+            return args[0] in (str, int, float) \
                    and cls.is_allowed_type(args[1])
 
     @classmethod
@@ -928,8 +931,9 @@ class SettingsHandler:
             return tuple(cls.unpack_value(x, tp_) for x, tp_ in zip(value, args))
         if orig is dict:
             kt, vt = args
-            return {cls.unpack_value(k, kt): cls.unpack_value(v, vt)
-                    for k, v in value.items()}
+            # Python's json encoder will convert ints, float, bools into strings
+            # we here just convert them back; we can't use unpack_value for this
+            return {kt(k): cls.unpack_value(v, vt) for k, v in value.items()}
 
         # Shouldn't come to this, but ... what the heck.
         return value

--- a/orangewidget/settings.py
+++ b/orangewidget/settings.py
@@ -513,12 +513,19 @@ class SettingsHandler:
 
     def read_defaults_file(self, settings_file: BinaryIO) -> None:
         """Read (global) defaults for this widget class from a file."""
+        def no_settings(impure):
+            pure = {}
+            for key, value in impure.items():
+                if isinstance(value, dict):
+                    pure[key] = no_settings(value)
+                elif isinstance(value, Setting):
+                    pure[key] = value.default
+                else:
+                    pure[key] = value
+            return pure
+
         defaults = pickle.load(settings_file)
-        self.defaults = {
-            key: value
-            for key, value in defaults.items()
-            if not isinstance(value, Setting)
-        }
+        self.defaults = no_settings(defaults)
         self._migrate_settings(self.defaults)
 
     def write_defaults(self) -> None:

--- a/orangewidget/settings.py
+++ b/orangewidget/settings.py
@@ -662,21 +662,6 @@ class SettingsHandler:
         self._prepare_defaults(widget)
         self.write_defaults()
 
-    def fast_save(self, widget, name, value):
-        """Store the (changed) widget's setting immediately to the context.
-
-        Parameters
-        ----------
-        widget : OWBaseWidget
-        name : str
-        value : object
-
-        """
-        if name in self.known_settings:
-            setting = self.known_settings[name]
-            if not setting.schema_only:
-                setting.default = value
-
     def reset_settings(self, widget: "OWBaseWidget") -> None:
         """Reset widget settings to defaults"""
         for setting, _, inst \
@@ -984,20 +969,6 @@ class ContextHandler(SettingsHandler):
                 yield setting.name, self.encode_setting(context, setting, value)
 
         context.values = self.provider.pack(widget, packer=packer)
-
-    def fast_save(self, widget, name, value):
-        """Update value of `name` setting in the current context to `value`
-        """
-        setting = self.known_settings.get(name)
-        if isinstance(setting, ContextSetting):
-            context = widget.current_context
-            if setting.schema_only or context is None:
-                return
-
-            value = self.encode_setting(context, setting, value)
-            self.update_packed_data(context.values, name, value)
-        else:
-            super().fast_save(widget, name, value)
 
     @staticmethod
     def update_packed_data(data: dict, name: str, value) -> None:

--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -322,7 +322,7 @@ class WidgetTest(GuiTest):
     def reset_default_settings(widget):
         """Reset default setting values for widget
 
-        Discards settings read from disk and changes stored by fast_save
+        Discards settings read from disk
 
         Parameters
         ----------

--- a/orangewidget/tests/test_context_handler.py
+++ b/orangewidget/tests/test_context_handler.py
@@ -263,6 +263,18 @@ class TestContextHandler(WidgetTest):
         self.assertTrue('context_setting' in global_values["component"])
         self.assertFalse('schema_only_context_setting' in global_values["component"])
 
+    def test_check_type_from_packer(self):
+        widget = SimpleWidget()
+        handler = widget.settingsHandler
+
+        widget.current_context = handler.new_context()
+        widget.context_setting = 13
+        handler.close_context(widget)
+
+        widget.current_context = handler.new_context()
+        widget.context_setting = "foo"
+        self.assertWarns(UserWarning, handler.close_context, widget)
+
 
 class TestSettingsPrinter(TestCase):
     def test_formats_contexts(self):

--- a/orangewidget/tests/test_context_handler.py
+++ b/orangewidget/tests/test_context_handler.py
@@ -149,19 +149,6 @@ class TestContextHandler(TestCase):
                 all(context.foo == i
                     for i, context in enumerate(contexts)))
 
-    def test_fast_save(self):
-        handler = ContextHandler()
-        handler.bind(SimpleWidget)
-
-        widget = SimpleWidget()
-        handler.initialize(widget)
-
-        context = widget.current_context = handler.new_context()
-        handler.fast_save(widget, 'context_setting', 55)
-        self.assertEqual(context.values['context_setting'], 55)
-        self.assertEqual(handler.known_settings['context_setting'].default,
-                         SimpleWidget.context_setting.default)
-
     def test_find_or_create_context(self):
         widget = SimpleWidget()
         handler = ContextHandler()
@@ -253,12 +240,6 @@ class TestContextHandler(TestCase):
         handler.initialize(widget)
         context = widget.current_context = handler.new_context()
         widget.context_settings.append(context)
-        handler.fast_save(widget, 'schema_only_context_setting', 5)
-        self.assertEqual(
-            handler.known_settings['schema_only_context_setting'].default, None)
-        handler.fast_save(widget, 'component.schema_only_context_setting', 5)
-        self.assertEqual(
-            handler.known_settings['component.schema_only_context_setting'].default, "only")
 
         # update_defaults should not update defaults
         widget.schema_only_context_setting = 5

--- a/orangewidget/tests/test_context_handler.py
+++ b/orangewidget/tests/test_context_handler.py
@@ -23,6 +23,7 @@ class SimpleWidget(QObject):
 
     setting = Setting(42)
     schema_only_setting = Setting(None, schema_only=True)
+    settingsHandler = ContextHandler()
 
     context_setting = ContextSetting(42)
     schema_only_context_setting = ContextSetting(None, schema_only=True)

--- a/orangewidget/tests/test_context_handler.py
+++ b/orangewidget/tests/test_context_handler.py
@@ -242,18 +242,18 @@ class TestContextHandler(TestCase):
         widget.context_settings.append(context)
 
         # update_defaults should not update defaults
-        widget.schema_only_context_setting = 5
+        widget.schema_only_context_setting = "foo"
         handler.update_defaults(widget)
         self.assertEqual(
             handler.known_settings['schema_only_context_setting'].default, None)
-        widget.component.schema_only_setting = 5
+        widget.component.schema_only_setting = "foo"
         self.assertEqual(
             handler.known_settings['component.schema_only_context_setting'].default, "only")
 
         # close_context should pack setting
-        widget.schema_only_context_setting = 5
-        widget.component.context_setting = 5
-        widget.component.schema_only_context_setting = 5
+        widget.schema_only_context_setting = "foo"
+        widget.component.context_setting = "foo"
+        widget.component.schema_only_context_setting = "foo"
         handler.close_context(widget)
         global_values = handler.global_contexts[0].values
         self.assertTrue('context_setting' in global_values)

--- a/orangewidget/tests/test_setting_provider.py
+++ b/orangewidget/tests/test_setting_provider.py
@@ -1,5 +1,10 @@
 import unittest
-from orangewidget.settings import Setting, SettingProvider
+import warnings
+from collections import namedtuple
+from enum import IntEnum
+from unittest.mock import Mock
+
+from orangewidget.settings import Setting, SettingProvider, _apply_setting
 
 SHOW_ZOOM_TOOLBAR = "show_zoom_toolbar"
 SHOW_GRAPH = "show_graph"

--- a/orangewidget/tests/test_setting_provider.py
+++ b/orangewidget/tests/test_setting_provider.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 
 from orangewidget.settings import Setting, SettingProvider, _apply_setting
 from orangewidget.tests.base import WidgetTest
-from orangewidget.widget import OWBaseWidget
+from orangewidget.widget import OWBaseWidget, OWComponent
 
 SHOW_ZOOM_TOOLBAR = "show_zoom_toolbar"
 SHOW_GRAPH = "show_graph"
@@ -40,7 +40,7 @@ def remove_base_settings(settings):
 class SettingProviderTestCase(WidgetTest):
     def setUp(self):
         global default_provider
-        default_provider = SettingProvider(Widget)
+        default_provider = Widget.settingsHandler.provider
 
     def tearDown(self):
         default_provider.settings[SHOW_GRAPH].default = True
@@ -104,7 +104,7 @@ class SettingProviderTestCase(WidgetTest):
         })
 
         self.assertFalse(hasattr(widget.graph, SHOW_Y_AXIS))
-        widget.graph = Graph()
+        widget.graph = Graph(widget)
         self.assertEqual(widget.graph.show_y_axis, False)
 
     def test_get_provider(self):
@@ -360,15 +360,13 @@ def initialize_settings(instance):
     provider = default_provider.get_provider(instance.__class__)
     if provider:
         provider.initialize(instance)
+
 default_provider = None
 """:type: SettingProvider"""
 
 
-class BaseGraph:
+class BaseGraph(OWComponent):
     show_labels = Setting(True)
-
-    def __init__(self):
-        initialize_settings(self)
 
 
 class Graph(BaseGraph):
@@ -396,8 +394,8 @@ class BaseWidget(OWBaseWidget, openclass=True):
     graph = SettingProvider(Graph)
 
     def __init__(self):
-        initialize_settings(self)
-        self.graph = Graph()
+        super().__init__()
+        self.graph = Graph(self)
 
 
 class Widget(BaseWidget):

--- a/orangewidget/tests/test_setting_provider.py
+++ b/orangewidget/tests/test_setting_provider.py
@@ -5,7 +5,9 @@ from enum import IntEnum
 from typing import Dict, List, Set
 from unittest.mock import Mock
 
-from orangewidget.settings import Setting, SettingProvider, _apply_setting
+import orangewidget.settings
+from orangewidget.settings import Setting, SettingProvider, _apply_setting, \
+    get_origin
 from orangewidget.tests.base import WidgetTest
 from orangewidget.widget import OWBaseWidget, OWComponent
 
@@ -308,7 +310,7 @@ class SettingProviderTestCase(WidgetTest):
         provider = SettingProvider(Widget)
         self.assertIs(provider.settings["a_bool"].type, bool)
         self.assertIs(provider.settings["a_list"].type, list)
-        self.assertIs(provider.settings["a_dict"].type.__origin__, dict)
+        self.assertIs(get_origin(provider.settings["a_dict"].type), dict)
         self.assertIs(provider.settings["sorting"].type, SortBy)
         self.assertIs(provider.settings["sorting2"].type, SortBy)
         self.assertIs(provider.settings["xy"].type, coords)

--- a/orangewidget/tests/test_setting_provider.py
+++ b/orangewidget/tests/test_setting_provider.py
@@ -1,11 +1,11 @@
 import unittest
 import warnings
-from enum import IntEnum
 from typing import Dict, List, Set
 from unittest.mock import Mock
 
 from orangewidget.settings import Setting, SettingProvider, _apply_setting
 from orangewidget.tests.base import WidgetTest
+from orangewidget.tests.utils import remove_base_settings
 from orangewidget.widget import OWBaseWidget, OWComponent
 
 SHOW_ZOOM_TOOLBAR = "show_zoom_toolbar"
@@ -19,14 +19,6 @@ ALLOW_ZOOMING = "allow_zooming"
 A_LIST = "a_list"
 A_SET = "a_set"
 A_DICT = "a_dict"
-
-
-def remove_base_settings(settings):
-    class HoneyPot(OWBaseWidget):
-        name = "honeypot"
-
-    for name in HoneyPot.settingsHandler.provider.settings:
-        settings.pop(name)
 
 
 class SettingProviderTestCase(WidgetTest):
@@ -128,7 +120,7 @@ class SettingProviderTestCase(WidgetTest):
                 SHOW_X_AXIS: True,
                 SHOW_Y_AXIS: False,
                 A_LIST: [],
-                A_SET: {1, 2, 3},
+                A_SET: [1, 2, 3],
                 A_DICT: {1: 2, 3: 4}
             },
             ZOOM_TOOLBAR: {

--- a/orangewidget/tests/test_setting_provider.py
+++ b/orangewidget/tests/test_setting_provider.py
@@ -1,13 +1,10 @@
 import unittest
 import warnings
-from collections import namedtuple
 from enum import IntEnum
 from typing import Dict, List, Set
 from unittest.mock import Mock
 
-import orangewidget.settings
-from orangewidget.settings import Setting, SettingProvider, _apply_setting, \
-    get_origin
+from orangewidget.settings import Setting, SettingProvider, _apply_setting
 from orangewidget.tests.base import WidgetTest
 from orangewidget.widget import OWBaseWidget, OWComponent
 
@@ -22,13 +19,6 @@ ALLOW_ZOOMING = "allow_zooming"
 A_LIST = "a_list"
 A_SET = "a_set"
 A_DICT = "a_dict"
-
-
-class SortBy(IntEnum):
-    NO_SORTING, INCREASING, DECREASING = range(3)
-
-
-coords = namedtuple("coords", ("x", "y"))
 
 
 def remove_base_settings(settings):
@@ -296,34 +286,6 @@ class SettingProviderTestCase(WidgetTest):
                 ALLOW_ZOOMING: widget.zoom_toolbar,
             }
         )
-
-    def test_settings_detect_types(self):
-        class Widget:
-            a_bool = Setting(True)
-            a_list = Setting([])
-            a_dict: Dict[str, int] = Setting(None)
-            sorting = Setting(SortBy.INCREASING)
-            sorting2: SortBy = Setting(None)
-            xy = Setting(coords(0, 0))
-            xy2: coords = Setting(None)
-
-        provider = SettingProvider(Widget)
-        self.assertIs(provider.settings["a_bool"].type, bool)
-        self.assertIs(provider.settings["a_list"].type, list)
-        self.assertIs(get_origin(provider.settings["a_dict"].type), dict)
-        self.assertIs(provider.settings["sorting"].type, SortBy)
-        self.assertIs(provider.settings["sorting2"].type, SortBy)
-        self.assertIs(provider.settings["xy"].type, coords)
-        self.assertIs(provider.settings["xy2"].type, coords)
-
-
-        with self.assertWarns(UserWarning):
-            class Widget2(OWBaseWidget):
-                name = "foo"
-                an_unknown = Setting(None)
-
-        self.assertIsNone(
-            Widget2.settingsHandler.provider.settings["an_unknown"].type)
 
     def assertDefaultSettingsEqual(self, provider, defaults):
         for name, value in defaults.items():

--- a/orangewidget/tests/test_settings.py
+++ b/orangewidget/tests/test_settings.py
@@ -1,0 +1,30 @@
+import unittest
+
+from orangewidget.settings import _cname, Setting
+
+
+class SettingTest(unittest.TestCase):
+    def test_nullable(self):
+        self.assertTrue(Setting(None).nullable)
+        self.assertFalse(Setting(42).nullable)
+
+    def test_type(self):
+        self.assertIsNone(Setting(None).type)
+        self.assertIs(Setting({}).type, dict)
+
+    def test_str(self):
+        str(Setting(None))
+        str(Setting(None, name="foo"))
+
+
+class UtilsTest(unittest.TestCase):
+    def test_cname(self):
+        self.assertEqual(_cname(int), "int")
+        self.assertEqual(_cname(dict), "dict")
+        self.assertEqual(_cname(42), "int")
+        self.assertEqual(_cname(42.0), "float")
+        self.assertEqual(_cname({3: 4}), "dict")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangewidget/tests/test_settings_handler.py
+++ b/orangewidget/tests/test_settings_handler.py
@@ -16,7 +16,7 @@ from orangewidget.tests.base import named_file, override_default_settings, \
     WidgetTest
 from orangewidget.settings import SettingsHandler, Setting, SettingProvider,\
     VERSION_KEY, rename_setting, Context
-from orangewidget.widget import OWBaseWidget
+from orangewidget.widget import OWBaseWidget, OWComponent
 
 
 class SettingHandlerTestCase(WidgetTest):
@@ -279,7 +279,7 @@ class SettingHandlerTestCase(WidgetTest):
             self.assertFalse(w)
 
 
-class Component:
+class Component(OWComponent):
     int_setting = Setting(42)
     schema_only_setting = Setting("only", schema_only=True)
 
@@ -298,7 +298,7 @@ class SimpleWidget(OWBaseWidget, openclass=True):
 
     def __init__(self):
         super().__init__()
-        self.component = Component()
+        self.component = Component(self)
 
     migrate_settings = Mock()
     migrate_context = Mock()

--- a/orangewidget/tests/test_settings_handler.py
+++ b/orangewidget/tests/test_settings_handler.py
@@ -529,6 +529,19 @@ class SettingHandlerTestCase(WidgetTest):
         widget.an_int = [0] * 100
         self.assertWarns(UserWarning, widget.settingsHandler.pack_data, widget)
 
+    def test_check_type_from_packer_tuple_suggestion(self):
+        class Widget(OWBaseWidget):
+            name = "foo"
+            a_tuple: Tuple[int] = Setting((42,))
+
+        widget = Widget()
+        widget.settingsHandler.pack_data(widget)
+        widget.a_tuple = (1, 2, 3)
+        with patch("warnings.warn") as warn:
+            widget.settingsHandler.pack_data(widget)
+        warn.assert_called_once()
+        self.assertIn("Tuple[T, ...]", warn.call_args[0][0])
+
     def test_pack_value(self):
         pv = SettingsHandler.pack_value
         self.assertEqual(pv(5, int), 5)

--- a/orangewidget/tests/test_settings_handler.py
+++ b/orangewidget/tests/test_settings_handler.py
@@ -174,76 +174,12 @@ class SettingHandlerTestCase(unittest.TestCase):
         SettingProvider.assert_called_once_with(SimpleWidget)
         provider.initialize.assert_called_once_with(widget, None)
 
-    def test_fast_save(self):
-        handler = SettingsHandler()
-
-        with override_default_settings(SimpleWidget):
-            handler.bind(SimpleWidget)
-
-        widget = SimpleWidget()
-
-        handler.fast_save(widget, 'component.int_setting', 5)
-
-        self.assertEqual(
-            handler.known_settings['component.int_setting'].default, 5)
-
-        self.assertEqual(Component.int_setting.default, 42)
-
-        handler.fast_save(widget, 'non_setting', 4)
-
-    def test_fast_save_siblings_spill(self):
-        handler_mk1 = SettingsHandler()
-        with override_default_settings(SimpleWidgetMk1):
-            handler_mk1.bind(SimpleWidgetMk1)
-
-        widget_mk1 = SimpleWidgetMk1()
-
-        handler_mk1.fast_save(widget_mk1, "setting", -1)
-        handler_mk1.fast_save(widget_mk1, "component.int_setting", 1)
-
-        self.assertEqual(
-            handler_mk1.known_settings['setting'].default, -1)
-        self.assertEqual(
-            handler_mk1.known_settings['component.int_setting'].default, 1)
-
-        handler_mk1.initialize(widget_mk1, data=None)
-        handler_mk1.provider.providers["component"].initialize(
-            widget_mk1.component, data=None)
-
-        self.assertEqual(widget_mk1.setting, -1)
-        self.assertEqual(widget_mk1.component.int_setting, 1)
-
-        handler_mk2 = SettingsHandler()
-        with override_default_settings(SimpleWidgetMk2):
-            handler_mk2.bind(SimpleWidgetMk2)
-
-        widget_mk2 = SimpleWidgetMk2()
-
-        handler_mk2.initialize(widget_mk2, data=None)
-        handler_mk2.provider.providers["component"].initialize(
-            widget_mk2.component, data=None)
-
-        self.assertEqual(widget_mk2.setting, 42,
-                         "spils defaults into sibling classes")
-
-        self.assertEqual(Component.int_setting.default, 42)
-
-        self.assertEqual(widget_mk2.component.int_setting, 42,
-                         "spils defaults into sibling classes")
-
     def test_schema_only_settings(self):
         handler = SettingsHandler()
         with override_default_settings(SimpleWidget):
             handler.bind(SimpleWidget)
 
-        # fast_save should not update defaults
         widget = SimpleWidget()
-        handler.fast_save(widget, 'schema_only_setting', 5)
-        self.assertEqual(
-            handler.known_settings['schema_only_setting'].default, None)
-        handler.fast_save(widget, 'component.schema_only_setting', 5)
-        self.assertEqual(
-            handler.known_settings['component.schema_only_setting'].default, "only")
 
         # update_defaults should not update defaults
         widget.schema_only_setting = 5

--- a/orangewidget/tests/test_settings_handler.py
+++ b/orangewidget/tests/test_settings_handler.py
@@ -158,25 +158,6 @@ class SettingHandlerTestCase(WidgetTest):
         handler.initialize(widget, pickle.dumps({'setting': 5}))
         provider.initialize.assert_called_once_with(widget, {'setting': 5})
 
-    @patch('orangewidget.settings.SettingProvider', create=True)
-    def test_initialize_with_no_provider(self, SettingProvider):
-        """:type SettingProvider: unittest.mock.Mock"""
-        handler = SettingsHandler()
-        handler.provider = Mock(get_provider=Mock(return_value=None))
-        handler.widget_class = SimpleWidget
-        provider = Mock()
-        SettingProvider.return_value = provider
-        widget = SimpleWidget()
-
-        # initializing an undeclared provider should display a warning
-        with warnings.catch_warnings(record=True) as w:
-            handler.initialize(widget)
-
-            self.assertEqual(1, len(w))
-
-        SettingProvider.assert_called_once_with(SimpleWidget)
-        provider.initialize.assert_called_once_with(widget, None)
-
     def test_schema_only_settings(self):
         handler = SettingsHandler()
         with override_default_settings(SimpleWidget):

--- a/orangewidget/tests/utils.py
+++ b/orangewidget/tests/utils.py
@@ -8,6 +8,9 @@ from AnyQt.QtTest import QTest
 from AnyQt.QtGui import QMouseEvent
 from AnyQt.QtWidgets import QApplication
 
+from orangewidget.settings import VERSION_KEY
+from orangewidget.widget import OWBaseWidget
+
 
 class EventSpy(QObject):
     """
@@ -313,3 +316,15 @@ def mouseMove(widget, pos=QPoint(), delay=-1):  # pragma: no-cover
         QTest.qWait(delay)
 
     QApplication.sendEvent(widget, me)
+
+
+def remove_base_settings(settings):
+    class HoneyPot(OWBaseWidget):
+        name = "honeypot"
+
+    for name in HoneyPot.settingsHandler.provider.settings:
+        settings.pop(name)
+
+    settings.pop(VERSION_KEY, None)
+    for context in settings.get("context_settings", []):
+        context["values"].pop(VERSION_KEY, None)

--- a/orangewidget/utils/filedialogs.py
+++ b/orangewidget/utils/filedialogs.py
@@ -9,7 +9,7 @@ from AnyQt.QtWidgets import \
     QMessageBox, QFileDialog, QFileIconProvider, QComboBox
 
 from orangewidget.io import Compression
-from orangewidget.settings import Setting, SettingsHandler
+from orangewidget.settings import Setting, SettingsHandler, TypeSupport
 
 if typing.TYPE_CHECKING:
     from typing_extensions import Protocol
@@ -297,31 +297,23 @@ class RecentPath:
     __str__ = __repr__
 
 
-def recent_paths_context_handler(base_handler: typing.Type[SettingsHandler]):
-    class ContextHandlerWRecentPaths(base_handler):
-        @classmethod
-        def is_allowed_type(cls, tp):
-            return tp is RecentPath or super().is_allowed_type(tp)
+class RecentPathTypeSupport(TypeSupport):
+    supported_types = (RecentPath, )
 
-        @classmethod
-        def pack_value(cls, value, tp):
-            if tp is RecentPath:
-                return {attr: getattr(value, attr)
-                        for attr in ("abspath", "prefix", "relpath",
-                                     "title", "sheet", "file_format")}
-            else:
-                return super().pack_value(value, tp)
+    @classmethod
+    def pack_value(cls, value, tp):
+        return {attr: getattr(value, attr)
+                for attr in ("abspath", "prefix", "relpath",
+                             "title", "sheet", "file_format")}
 
-        @classmethod
-        def unpack_value(cls, value, tp):
-            if tp is RecentPath:
-                if isinstance(value, RecentPath):  # backward compatibility
-                    return value
-                return RecentPath(**value)
-            else:
-                return super().unpack_value(value, tp)
-
-    return ContextHandlerWRecentPaths
+    @classmethod
+    def unpack_value(cls, value, tp, *args):
+        if tp is RecentPath:
+            if isinstance(value, RecentPath):  # backward compatibility
+                return value
+            return RecentPath(**value)
+        else:
+            return super().unpack_value(value, tp, *args)
 
 
 class RecentPathsWidgetMixin:
@@ -357,7 +349,9 @@ class RecentPathsWidgetMixin:
     #: list with search paths; overload to add, say, documentation datasets dir
     SEARCH_PATHS = []
 
-    recent_paths: typing.List[RecentPath] = Setting([])
+    # This must be in the widget, not the mixin - otherwise all widgets will
+    # share the same paths
+    # recent_paths: typing.List[RecentPath] = Setting([])
 
     _init_called = False
 

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -279,7 +279,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     messageActivated = Signal(Msg)
     messageDeactivated = Signal(Msg)
 
-    savedWidgetGeometry = settings.Setting(None)
+    savedWidgetGeometry: bytes = settings.Setting(None)
     controlAreaVisible = settings.Setting(True, schema_only=True)
 
     # pylint: disable=protected-access, access-member-before-definition

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -375,7 +375,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                     "subclassing of widget classes is deprecated and will be "
                     "disabled in the future.\n"
                     f"Extract code from {base.__name__} or explicitly open it.",
-                    RuntimeWarning)
+                    RuntimeWarning, stacklevel=3)
                 # raise TypeError(f"class {base.__name__} cannot be subclassed")
 
     @classmethod


### PR DESCRIPTION
##### Issue

Implements #20.

##### Description of changes

PR defines a set of allowed types and requires proper annotations when the type is not deducible from the default.

- The list of allowed types includes `IntEnum` and `NamedTuple`, as well as `set`, `tuple` and `bytes` which can easily be converted before encoding to json.
- Context handlers can add other valid types, though they are expected to encode them, like, for instance, `Variable` which is already encoded into tuple.
- If setting's default is an empty `list`, `set`, `dict` or `tuple`, it must be annotated, e.g. as `List[int]`. All these must be homogenous; named `tuple` is an exception.
- Type checking is deep, e.g. a `List` must contain only elements of allowed types. Dict's keys must be `int`, `float`, `str` or `bool`, to match those allowed in json.

Also:
- `savedWidgetGeometry` is base64-encoded into strings (this may be reverted because `bytes` will be allowed).

**To do**: Handlers will provide encoding to json and decoding from it. `IntEnum` will become an int, `bytes` will be base64-encoded, and `NamedTuple`, `set`, `tuple` will be encoded as lists. Decoding to proper type can be done because types are annotated. When encoding to json fails, handler will fallback to pickle.

As things stand now, types like `Variable` are already encoded to tuple when settings are packed into a dict. Packed dicts thus contain only valid types that are described above. Hence, encoding will be done in the base `SettingsHandler`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
