### PR TITLE
open_filename_dialog: fix for returned empty filter

### DIFF
--- a/orangewidget/utils/filedialogs.py
+++ b/orangewidget/utils/filedialogs.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import typing
-from fnmatch import fnmatch
 from typing import Tuple
 
 from AnyQt.QtCore import QFileInfo, Qt
@@ -162,21 +161,11 @@ def open_filename_dialog(start_dir: str, start_filter: str, file_formats,
     if not filename:
         return None, None, None
 
-    if filter and not (add_all and filter == filters[0]):
+    if filter in filters:
         file_format = file_formats[filters.index(filter)]
     else:
-        base = os.path.basename(filename)
-        for file_format in file_formats[add_all:]:
-            if any(fnmatch(base, '*' + ext)
-                   for ext in file_format.EXTENSIONS
-                   # Skip ambiguous compression-only extensions added on OSX
-                   if ext not in Compression.all):
-                break
-        else:
-            # This shouldn't happen, but if it does, returning the first
-            # filter is the best we can do. Let the reader fail then.
-            file_format = file_formats[1 if add_all else 0]
-        filter = format_filter(file_format)
+        file_format = None
+        filter = None
 
     return filename, file_format, filter
 

--- a/orangewidget/utils/tests/test_filedialogs.py
+++ b/orangewidget/utils/tests/test_filedialogs.py
@@ -25,62 +25,17 @@ class TestRecentPath(unittest.TestCase):
 
 class TestOpenFilenameDialog(unittest.TestCase):
     def test_empty_filter(self):
-        class XYZFormat:
-            EXTENSIONS = ('.xyz',)
-            DESCRIPTION = 'xyz file'
-            PRIORITY = 20
-
-        class XYZGZFormat:
-            EXTENSIONS = ('.xyz.gz',)
-            DESCRIPTION = 'Compressed xyz file'
-            PRIORITY = 20
-
         class ABCFormat:
             EXTENSIONS = ('.abc', '.jkl')
             DESCRIPTION = 'abc file'
             PRIORITY = 30
 
         name, file_format, file_filter = open_filename_dialog(
-            ".", "", [ABCFormat, XYZFormat],
+            ".", "", [ABCFormat],
             dialog=Mock(return_value=("foo.xyz", "")))
         self.assertEqual(name, "foo.xyz")
-        self.assertEqual(file_format, XYZFormat)
-        self.assertEqual(file_filter, "xyz file (*.xyz)")
-
-        name, file_format, file_filter = open_filename_dialog(
-            ".", "", [ABCFormat, XYZFormat, XYZGZFormat],
-            dialog=Mock(return_value=("foo.xyz.gz", "")))
-        self.assertEqual(name, "foo.xyz.gz")
-        self.assertEqual(file_format, XYZGZFormat)
-        self.assertEqual(file_filter, "Compressed xyz file (*.xyz.gz)")
-
-        name, file_format, file_filter = open_filename_dialog(
-            ".", "", [ABCFormat, XYZFormat],
-            dialog=Mock(return_value=("foo.abc", "")))
-        self.assertEqual(name, "foo.abc")
-        self.assertEqual(file_format, ABCFormat)
-        self.assertEqual(file_filter, "abc file (*.abc *.jkl)")
-
-        name, file_format, file_filter = open_filename_dialog(
-            ".", "", [ABCFormat, XYZFormat],
-            dialog=Mock(return_value=("foo.jkl", "")))
-        self.assertEqual(name, "foo.jkl")
-        self.assertEqual(file_format, ABCFormat)
-        self.assertEqual(file_filter, "abc file (*.abc *.jkl)")
-
-        name, file_format, file_filter = open_filename_dialog(
-            ".", "", [ABCFormat, XYZFormat],
-            dialog=Mock(return_value=("foo.def", "")))
-        self.assertEqual(name, "foo.def")
-        self.assertEqual(file_format, XYZFormat)
-        self.assertEqual(file_filter, "xyz file (*.xyz)")
-
-        name, file_format, file_filter = open_filename_dialog(
-            ".", "", [ABCFormat, XYZFormat],
-            dialog=Mock(return_value=("foo.def", "")), add_all=False)
-        self.assertEqual(name, "foo.def")
-        self.assertEqual(file_format, XYZFormat)
-        self.assertEqual(file_filter, "xyz file (*.xyz)")
+        self.assertEqual(file_format, None)
+        self.assertEqual(file_filter, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Aims to do the same thing as #53 but with smaller changes to behaviour.

Keeps 

##### Issue
#53 broke:
- Tests in OWFile, which expected None if there was no filter selected. This was already fixed in master, but I think that what the OWFile test expected was fine. Perhaps it would sometimes be useful to know that the user did not choose any specific format
- OWMultifile, because it assumed that all dialogs are going to return strings. Well, some return lists of strings.
- Possibly changed which readers open files, because priorities, which are important when a certain extension can be opened by multiple readers, were handled differently.

#53 added unneeded complexity into a single function, while also semi-duplicating existing functionality.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
