### PR TITLE
[ENH] Visual settings: saving settings, custom dialogs

### DIFF
--- a/orangewidget/utils/tests/test_visual_settings_dlg.py
+++ b/orangewidget/utils/tests/test_visual_settings_dlg.py
@@ -62,6 +62,18 @@ class TestVisualSettingsDialog(GuiTest):
         self.dialog_controls[("Box", "Items", "P3")][0].setChecked(False)
         handler.assert_called_with(('Box', 'Items', 'P3'), False)
 
+    def test_apply_settings(self):
+        changed = [(("Box", "Items", "P1"), "Foo"),
+                   (("Box", "Items", "P2"), 7),
+                   (("Box", "Items", "P3"), False)]
+        self.dlg.apply_settings(changed)
+        ctrls = self.dialog_controls
+        self.assertEqual(ctrls[("Box", "Items", "P1")][0].currentText(), "Foo")
+        self.assertEqual(ctrls[("Box", "Items", "P2")][0].value(), 7)
+        self.assertEqual(ctrls[("Box", "Items", "P3")][0].isChecked(), False)
+        self.assertDictEqual(self.dlg.changed_settings,
+                             {k: v for k, v in changed})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/orangewidget/utils/tests/test_visual_settings_dlg.py
+++ b/orangewidget/utils/tests/test_visual_settings_dlg.py
@@ -1,28 +1,26 @@
 import unittest
 from unittest.mock import Mock
-from collections import OrderedDict
 
 from AnyQt.QtWidgets import QComboBox, QCheckBox, QSpinBox
 
 from orangewidget.tests.base import GuiTest
-from orangewidget.utils.visual_settings_dlg import VisualSettingsDialog
+from orangewidget.utils.visual_settings_dlg import SettingsDialog
 
 
-class TestVisualSettingsDialog(GuiTest):
+class TestSettingsDialog(GuiTest):
     def setUp(self):
         self.defaults = {
-            "Box": {"Items": OrderedDict({
+            "Box": {"Items": {
                 "P1": (["Foo", "Bar", "Baz"], "Bar"),
                 "P2": (range(3, 10, 2), 5),
                 "P3": (None, True),
-            })}
+            }}
         }
-        self.dlg = VisualSettingsDialog(None)
-        self.dlg.initialize(self.defaults)
+        self.dlg = SettingsDialog(None, self.defaults)
 
     @property
     def dialog_controls(self):
-        return self.dlg._VisualSettingsDialog__controls
+        return self.dlg._SettingsDialog__controls
 
     def test_initialize(self):
         controls = self.dialog_controls
@@ -46,7 +44,7 @@ class TestVisualSettingsDialog(GuiTest):
         ctrls[("Box", "Items", "P2")][0].setValue(7)
         ctrls[("Box", "Items", "P3")][0].setChecked(False)
 
-        self.dlg._VisualSettingsDialog__reset()
+        self.dlg._SettingsDialog__reset()
         self.assertDictEqual(self.dlg.changed_settings, {})
         self.assertEqual(ctrls[("Box", "Items", "P1")][0].currentText(), "Bar")
         self.assertEqual(ctrls[("Box", "Items", "P2")][0].value(), 5)

--- a/orangewidget/utils/visual_settings_dlg.py
+++ b/orangewidget/utils/visual_settings_dlg.py
@@ -91,6 +91,18 @@ class VisualSettingsDialog(QDialog):
             self.__controls[key] = (control, default_value)
         form.addRow(f"{label}:", box)
 
+    def apply_settings(self, settings: Iterable[Tuple[Tuple[str], Union[str, int, bool]]]):
+        """ Assign values to controls.
+
+        Parameters
+        ----------
+        settings : Iterable[Tuple[Tuple[str], Union[str, int, bool]]
+            Collection of box names, label texts, parameter names
+            and control values.
+        """
+        for key, value in settings:
+            _set_control_value(self.__controls[key][0], value)
+
     def show_dlg(self):
         """ Open the dialog. """
         self.show()

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -24,7 +24,6 @@ from orangewidget.gui import OWComponent, VerticalScrollArea
 from orangewidget.io import ClipboardFormat, ImgFormat
 from orangewidget.settings import SettingsHandler
 from orangewidget.utils import saveplot, getdeepattr
-from orangewidget.utils.visual_settings_dlg import VisualSettingsDialog
 from orangewidget.utils.progressbar import ProgressBarMixin
 from orangewidget.utils.messages import (
     WidgetMessagesMixin, UnboundMsg, MessagesWidget
@@ -155,8 +154,6 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                      and getattr(f, "EXTENSIONS", None)]
 
     save_position = True
-    #: Used for visual settings dialog initialization
-    initial_visual_settings = None  # type: Dict
 
     #: If false the widget will receive fixed size constraint
     #: (derived from it's layout). Use for widgets which have simple
@@ -199,6 +196,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     contextAboutToBeOpened = Signal(object)
     contextOpened = Signal()
     contextClosed = Signal()
+    openVisualSettingsClicked = Signal()
 
     # pylint: disable=protected-access, access-member-before-definition
     def __new__(cls, *args, captionTitle=None, **kwargs):
@@ -611,16 +609,11 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                 b.clicked.connect(self.reset_settings)
                 buttonsLayout.addWidget(b)
             if hasattr(self, "set_visual_settings"):
-                assert self.initial_visual_settings is not None
-                dlg = VisualSettingsDialog(self)
-                dlg.initialize(self.initial_visual_settings)
-                dlg.setting_changed.connect(self.set_visual_settings)
-
                 icon = QIcon(gui.resource_filename("icons/visual-settings.svg"))
                 icon.addFile(gui.resource_filename("icons/visual-settings-hover.svg"),
                              mode=QIcon.Active)
                 b = SimpleButton(icon=icon, toolTip="Set visual settings")
-                b.clicked.connect(dlg.show_dlg)
+                b.clicked.connect(self.openVisualSettingsClicked)
                 buttonsLayout.addWidget(b)
 
             buttons = QWidget(objectName="buttons")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
User is forced to use the predefined dialog when clicking upon the Visual Settings icon in the status bar.

##### Description of changes
- Enable using custom Visual settings dialog
- Enable using saved settings
- Remove OrderedDict

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
