### PR TITLE
Remove deprecated maximumContentLength from combobox

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -1404,8 +1404,7 @@ def valueSlider(widget, master, value, box=None, label=None,
 def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
              orientation=Qt.Vertical, items=(), callback=None,
              sendSelectedValue=None, emptyString=None, editable=False,
-             contentsLength=None, maximumContentsLength=25, searchable=False,
-             *, model=None, **misc):
+             contentsLength=None, searchable=False, *, model=None, **misc):
     """
     Construct a combo box.
 
@@ -1448,17 +1447,10 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
             combo.setSizeAdjustPolicy(
                 QComboBox.AdjustToMinimumContentsLengthWithIcon)
             combo.setMinimumContentsLength(contentsLength)
-    :param int maximumContentsLength: deprecated 4.5.0
     :param searchable: decides whether combo box has search-filter option
     :type searchable: bool
     :rtype: QComboBox
     """
-    if maximumContentsLength != 25:
-        warnings.warn(
-            f"'maximumContentsLength' is deprecated and has no effect. It "
-            "will be removed in orange-widget-base 4.6",
-            FutureWarning
-        )
     widget_label = None
     if box or label:
         hb = widgetBox(widget, box, orientation, addToLayout=False)

--- a/orangewidget/utils/combobox.py
+++ b/orangewidget/utils/combobox.py
@@ -25,14 +25,7 @@ class ComboBox(QComboBox):
     Prefer to use this class in place of plain QComboBox when the used
     model will possibly contain many items.
     """
-    def __init__(self, parent=None, maximumContentsLength=-1, **kwargs):
-        if maximumContentsLength != -1:
-            warnings.warn(
-                f"'{__name__}.ComboBox.maximumContentsLength' is deprecated "
-                "and has no effect. It will be removed in orange-widget-base "
-                "4.6",
-                FutureWarning
-            )
+    def __init__(self, parent=None, **kwargs):
         self.__maximumContentsLength = MAXIMUM_CONTENTS_LENGTH
         super().__init__(parent, **kwargs)
 

--- a/orangewidget/utils/tests/test_combobox.py
+++ b/orangewidget/utils/tests/test_combobox.py
@@ -140,14 +140,3 @@ class TestComboBoxSearch(GuiTest):
             geom, QRect(0, 500, 100, 20), screen
         )
         self.assertEqual(g4, QRect(0, 500 - 400, 100, 400))
-
-    def test_deprecation(self):
-        """
-        When this test fails remove maximumContentsLength. Also remove
-        maximumContentsLength from gui.comboBox
-        """
-        version = pkg_resources.get_distribution("orange-widget-base").version
-        self.assertLess(
-            version, "4.7.0",
-            "Remove maximumContentsLength from ComboBox class and this test."
-        )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The maximum content length was deprecated few versions ago

##### Description of changes
With this PR it is removed

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
