### PR TITLE
tests/base: Disable macOS app nap in tests

### DIFF
--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -162,6 +162,15 @@ class GuiTest(unittest.TestCase):
         global app
         if app is None:
             app = QApplication([])
+        # Disable App Nap on macOS (see
+        # https://codereview.qt-project.org/c/qt/qtbase/+/202515 for more)
+        if sys.platform == "darwin":
+            try:
+                import appnope
+            except ImportError:
+                pass
+            else:
+                appnope.nope()
         super().setUpClass()
 
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ INSTALL_REQUIRES = [
     "pyqtgraph",
     "AnyQt",
     "orange-canvas-core>=0.1.8a,<0.2a",
+    'appnope; sys_platform=="darwin"'
 ]
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Orange3 macOS tests sometimes stall. One possible reason is macOS App Nap (https://codereview.qt-project.org/c/qt/qtbase/+/202515)

##### Description of changes

Disable App Nap when running GUI tests

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
