### PR TITLE
VisualSettingsDialog: Add support for LineEdit, add tooltips

### DIFF
--- a/orangewidget/utils/tests/test_visual_settings_dlg.py
+++ b/orangewidget/utils/tests/test_visual_settings_dlg.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import Mock
 
-from AnyQt.QtWidgets import QComboBox, QCheckBox, QSpinBox
+from AnyQt.QtWidgets import QComboBox, QCheckBox, QSpinBox, QLineEdit
 
 from orangewidget.tests.base import GuiTest
 from orangewidget.utils.visual_settings_dlg import SettingsDialog
@@ -14,6 +14,7 @@ class TestSettingsDialog(GuiTest):
                 "P1": (["Foo", "Bar", "Baz"], "Bar"),
                 "P2": (range(3, 10, 2), 5),
                 "P3": (None, True),
+                "P4": (None, "Foo Bar"),
             }}
         }
         self.dlg = SettingsDialog(None, self.defaults)
@@ -28,14 +29,17 @@ class TestSettingsDialog(GuiTest):
         self.assertIsInstance(controls[("Box", "Items", "P1")][0], QComboBox)
         self.assertIsInstance(controls[("Box", "Items", "P2")][0], QSpinBox)
         self.assertIsInstance(controls[("Box", "Items", "P3")][0], QCheckBox)
+        self.assertIsInstance(controls[("Box", "Items", "P4")][0], QLineEdit)
 
     def test_changed_settings(self):
         self.dialog_controls[("Box", "Items", "P1")][0].setCurrentText("Foo")
         self.dialog_controls[("Box", "Items", "P2")][0].setValue(7)
         self.dialog_controls[("Box", "Items", "P3")][0].setChecked(False)
+        self.dialog_controls[("Box", "Items", "P4")][0].setText("Foo Baz")
         changed = {("Box", "Items", "P1"): "Foo",
                    ("Box", "Items", "P2"): 7,
-                   ("Box", "Items", "P3"): False}
+                   ("Box", "Items", "P3"): False,
+                   ("Box", "Items", "P4"): "Foo Baz"}
         self.assertDictEqual(self.dlg.changed_settings, changed)
 
     def test_reset(self):
@@ -43,12 +47,14 @@ class TestSettingsDialog(GuiTest):
         ctrls[("Box", "Items", "P1")][0].setCurrentText("Foo")
         ctrls[("Box", "Items", "P2")][0].setValue(7)
         ctrls[("Box", "Items", "P3")][0].setChecked(False)
+        ctrls[("Box", "Items", "P4")][0].setText("Foo Baz")
 
         self.dlg._SettingsDialog__reset()
         self.assertDictEqual(self.dlg.changed_settings, {})
         self.assertEqual(ctrls[("Box", "Items", "P1")][0].currentText(), "Bar")
         self.assertEqual(ctrls[("Box", "Items", "P2")][0].value(), 5)
         self.assertTrue(ctrls[("Box", "Items", "P3")][0].isChecked())
+        self.assertEqual(ctrls[("Box", "Items", "P4")][0].text(), "Foo Bar")
 
     def test_setting_changed(self):
         handler = Mock()
@@ -59,16 +65,20 @@ class TestSettingsDialog(GuiTest):
         handler.assert_called_with(('Box', 'Items', 'P2'), 7)
         self.dialog_controls[("Box", "Items", "P3")][0].setChecked(False)
         handler.assert_called_with(('Box', 'Items', 'P3'), False)
+        self.dialog_controls[("Box", "Items", "P4")][0].setText("Foo Baz")
+        handler.assert_called_with(('Box', 'Items', 'P4'), "Foo Baz")
 
     def test_apply_settings(self):
         changed = [(("Box", "Items", "P1"), "Foo"),
                    (("Box", "Items", "P2"), 7),
-                   (("Box", "Items", "P3"), False)]
+                   (("Box", "Items", "P3"), False),
+                   (("Box", "Items", "P4"), "Foo Baz")]
         self.dlg.apply_settings(changed)
         ctrls = self.dialog_controls
         self.assertEqual(ctrls[("Box", "Items", "P1")][0].currentText(), "Foo")
         self.assertEqual(ctrls[("Box", "Items", "P2")][0].value(), 7)
-        self.assertEqual(ctrls[("Box", "Items", "P3")][0].isChecked(), False)
+        self.assertFalse(ctrls[("Box", "Items", "P3")][0].isChecked())
+        self.assertEqual(ctrls[("Box", "Items", "P4")][0].text(), "Foo Baz")
         self.assertDictEqual(self.dlg.changed_settings,
                              {k: v for k, v in changed})
 

--- a/orangewidget/utils/visual_settings_dlg.py
+++ b/orangewidget/utils/visual_settings_dlg.py
@@ -91,6 +91,7 @@ class SettingsDialog(QDialog):
             key = (box_name, label, parameter)
             control = _add_control(values or default_value, default_value, box,
                                    key, self.setting_changed)
+            control.setToolTip(parameter)
             self.__controls[key] = (control, default_value)
         form.addRow(f"{label}:", box)
 

--- a/orangewidget/utils/visual_settings_dlg.py
+++ b/orangewidget/utils/visual_settings_dlg.py
@@ -89,9 +89,10 @@ class SettingsDialog(QDialog):
         box = gui.hBox(None, box=None)
         for parameter, (values, default_value) in settings.items():
             key = (box_name, label, parameter)
-            control = _add_control(values or default_value, default_value, box,
-                                   key, self.setting_changed)
+            control = _add_control(values or default_value, default_value, key,
+                                   self.setting_changed)
             control.setToolTip(parameter)
+            box.layout().addWidget(control)
             self.__controls[key] = (control, default_value)
         form.addRow(f"{label}:", box)
 
@@ -147,40 +148,34 @@ def _add_control(*_):
 
 
 @_add_control.register(list)
-def _(values: List[str], value: str, parent: QGroupBox, key: KeyType,
-      signal: Callable) -> QComboBox:
+def _(values: List[str], value: str, key: KeyType, signal: Callable) \
+        -> QComboBox:
     combo = QComboBox()
     combo.addItems(values)
     combo.setCurrentText(value)
-    parent.layout().addWidget(combo)
     combo.currentTextChanged.connect(lambda text: signal.emit(key, text))
     return combo
 
 
 @_add_control.register(range)
-def _(values: Iterable[int], value: int, parent: QGroupBox, key: KeyType,
-      signal: Callable) -> QSpinBox:
+def _(values: Iterable[int], value: int, key: KeyType, signal: Callable) \
+        -> QSpinBox:
     spin = QSpinBox(minimum=values.start, maximum=values.stop,
                     singleStep=values.step, value=value)
-    parent.layout().addWidget(spin)
     spin.valueChanged.connect(lambda val: signal.emit(key, val))
     return spin
 
 
 @_add_control.register(bool)
-def _(_: bool, value: bool, parent: QGroupBox, key: KeyType,
-      signal: Callable) -> QCheckBox:
+def _(_: bool, value: bool, key: KeyType, signal: Callable) -> QCheckBox:
     check = QCheckBox(text=f"{key[-1]} ", checked=value)
-    parent.layout().addWidget(check)
     check.stateChanged.connect(lambda val: signal.emit(key, bool(val)))
     return check
 
 
 @_add_control.register(str)
-def _(_: str, value: str, parent: QGroupBox, key: KeyType,
-      signal: Callable) -> QLineEdit:
+def _(_: str, value: str, key: KeyType, signal: Callable) -> QLineEdit:
     line_edit = QLineEdit(value)
-    parent.layout().addWidget(line_edit)
     line_edit.textChanged.connect(lambda text: signal.emit(key, text))
     return line_edit
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The Visual Settings dialog should support text editing (e.g. axis title).

##### Description of changes
- add support for LineEdit control to enable text editing.
- add tooltips
- refactor

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
