### PR TITLE
gui: Align controls (QTBUG-2699 workaround)

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -800,6 +800,10 @@ def checkBox(widget, master, value, label, box=None,
     cbox.toggled[bool].connect(cbox.makeConsistent)
     cbox.makeConsistent(value)
     miscellanea(cbox, b, widget, **misc)
+
+    # QTBUG-2699
+    cbox.setAttribute(Qt.WA_LayoutUsesWidgetRect)
+
     return cbox
 
 
@@ -999,6 +1003,10 @@ def button(widget, master, label, callback=None, width=None, height=None,
         button.clicked.connect(callback)
 
     miscellanea(button, None, widget, **misc)
+
+    # QTBUG-2699
+    button.setAttribute(Qt.WA_LayoutUsesWidgetRect)
+
     return button
 
 
@@ -1515,6 +1523,10 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
         log.warning("comboBox no longer accepts argument 'valueType'")
     miscellanea(combo, hb, widget, **misc)
     combo.emptyString = emptyString
+
+    # QTBUG-2699
+    combo.setAttribute(Qt.WA_LayoutUsesWidgetRect)
+
     return combo
 
 


### PR DESCRIPTION
##### Description of changes
Some elements (push buttons, comboboxes, checkboxes) have an additional margin at the start of their layout, if they're in a nested layout. That way, these two checkboxes aren't vertically aligned (2px off):
![Screenshot 2020-06-20 at 16 27 17](https://user-images.githubusercontent.com/24586651/85207914-791b8100-b32c-11ea-88aa-5db795df9ed9.png)

This is what's happening under the hood:
![Screenshot 2020-06-20 at 19 25 33](https://user-images.githubusercontent.com/24586651/85207923-8df81480-b32c-11ea-97fc-90491ce103dc.png)

By setting the `WA_LayoutUsesWidgetRect` attribute on all created buttons, comboboxes and checkboxes, you get this:
![Screenshot 2020-06-20 at 19 25 15](https://user-images.githubusercontent.com/24586651/85207939-ab2ce300-b32c-11ea-94c4-23541e1eba31.png)

Without overwriting the stylesheet:
![Screenshot 2020-06-20 at 19 34 16](https://user-images.githubusercontent.com/24586651/85207980-0bbc2000-b32d-11ea-9ce6-4455e33f642f.png)

This leads to taller control boxes. In this specific screenshot, it's 6px taller.

It seems to apply to `QPushButton`s, `QComboBox`es, `QCheckBox`es and possibly other items.
https://stackoverflow.com/questions/41452512/how-to-remove-margins-of-qlayout-completely-mac-os-specific

There was a bug reported to QT, but it looks like nothing was done of it due to the existence of a workaround.
https://bugreports.qt.io/browse/QTBUG-2699

##### RFC

- [ ] I've read that this **only happens on Mac**, it's necessary to test what this change looks like on other platforms.
- [ ] How to make the controls shorter? Perhaps in a way which would also remove the extra space at the bottom of each box?
- [ ] Are there any other misaligned elements which this should be applied to?

##### Minimal code example

```python
#!/usr/bin/python

import sys

from PyQt5.QtCore import Qt
from PyQt5.QtWidgets import QApplication, QWidget, QGroupBox, QVBoxLayout, QGridLayout, \
    QRadioButton, QHBoxLayout


def main():

    app = QApplication(sys.argv)

    w = QWidget()
    w.setLayout(QGridLayout())

    gbox = QWidget(w)
    gbox.setStyleSheet('QWidget { background: red; }')
    layout = QVBoxLayout(gbox)
    layout.setAlignment(Qt.AlignLeft)

    b1 = QRadioButton('Hi', gbox)
    b1.setStyleSheet('QWidget { background: blue; }')
    layout.addWidget(b1)

    b2 = QRadioButton('Hi2', gbox)
    b2.setStyleSheet('QWidget { background: blue; }')
    l2 = QHBoxLayout(gbox)
    l2.addWidget(b2)

    # doesn't do anything
    l2.setContentsMargins(0, 0, 0, 0)

    # -||- either
    l2.setSpacing(0)

    # nope
    l2.layout().setContentsMargins(0, 0, 0, 0)

    # boom!
    b1.setAttribute(Qt.WA_LayoutUsesWidgetRect)
    # b2.setAttribute(Qt.WA_LayoutUsesWidgetRect)

    layout.addLayout(l2)
    gbox.setLayout(layout)

    w.layout().addWidget(gbox)
    w.resize(250, 150)
    w.move(300, 300)
    w.setWindowTitle('Simple')
    w.show()

    sys.exit(app.exec_())


if __name__ == '__main__':
    main()
```
