### PR TITLE
VisualSettingsDialog: Rename OK button to Close

### DIFF
--- a/orangewidget/utils/visual_settings_dlg.py
+++ b/orangewidget/utils/visual_settings_dlg.py
@@ -45,9 +45,9 @@ class SettingsDialog(QDialog):
 
         buttons = QDialogButtonBox(
             orientation=Qt.Horizontal,
-            standardButtons=QDialogButtonBox.Ok | QDialogButtonBox.Reset,
+            standardButtons=QDialogButtonBox.Close | QDialogButtonBox.Reset,
         )
-        buttons.accepted.connect(self.accept)
+        buttons.button(QDialogButtonBox.Close).clicked.connect(self.close)
         buttons.button(QDialogButtonBox.Reset).clicked.connect(self.__reset)
         layout.addWidget(buttons)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Button OK is misleading; it doesn't confirm the changes (as opposed to Cancel), it just closes the window. Perhaps rename to Close, or you can eliminate it.

##### Description of changes
Rename the button to Close.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
