### PR TITLE
[FIX] report: Avoid use of processEvents (via evalJS -> wait)

### DIFF
--- a/orangewidget/report/index.html
+++ b/orangewidget/report/index.html
@@ -127,7 +127,29 @@
         }
     }
     </style>
+    <script>
+    function scrollToId(id) {
+        var sel_el = document.getElementById(id);
+        if (sel_el != undefined) {
+            sel_el.scrollIntoView();
+            return true;
+        }
+        return false;
+    };
 
+    function setSelectedId(id) {
+        var sel_el = document.getElementsByClassName('selected')[0];
+        if (sel_el != undefined && sel_el.id != id) {
+           sel_el.className = 'normal';
+        }
+        sel_el = document.getElementById(id);
+        if (sel_el != undefined) {
+            sel_el.className = 'selected';
+            return true;
+        }
+        return false;
+    };
+    </script>
 
 <body>
 

--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -179,6 +179,7 @@ class GuiTest(unittest.TestCase):
             import pyqtgraph
             pyqtgraph.setConfigOption("exitCleanup", False)
         super().tearDownClass()
+        QTest.qWait(0)
 
 
 class WidgetTest(GuiTest):
@@ -232,12 +233,12 @@ class WidgetTest(GuiTest):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        super().tearDownClass()
         cls.widgets.clear()
+        super().tearDownClass()
 
     def tearDown(self):
         """Process any pending events before the next test is executed."""
-        self.process_events()
+        QTest.qWait(0)
         super().tearDown()
 
     def create_widget(self, cls, stored_settings=None, reset_default_settings=True):

--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -8,7 +8,7 @@ import tempfile
 
 import time
 import unittest
-from contextlib import contextmanager
+from contextlib import contextmanager, ExitStack
 from unittest.mock import Mock, patch
 from typing import List, Optional, TypeVar, Type
 
@@ -153,6 +153,8 @@ class GuiTest(unittest.TestCase):
 
     GuiTest ensures that a QApplication exists before tests are run an
     """
+    tear_down_stack: ExitStack
+
     @classmethod
     def setUpClass(cls):
         """Prepare for test execution.
@@ -171,13 +173,16 @@ class GuiTest(unittest.TestCase):
                 pass
             else:
                 appnope.nope()
+        cls.tear_down_stack = ExitStack()
         super().setUpClass()
+
 
     @classmethod
     def tearDownClass(cls) -> None:
         if "pyqtgraph" in sys.modules:
             import pyqtgraph
             pyqtgraph.setConfigOption("exitCleanup", False)
+        cls.tear_down_stack.close()
         super().tearDownClass()
         QTest.qWait(0)
 
@@ -227,7 +232,11 @@ class WidgetTest(GuiTest):
 
         report = OWReport()
         cls.widgets.append(report)
-        OWReport.get_instance = lambda: report
+
+        cls.tear_down_stack.enter_context(
+            patch.object(OWReport, "get_instance", lambda: report)
+        )
+
         if not (os.environ.get("TRAVIS") or os.environ.get("APPVEYOR")):
             report.show = Mock()
 

--- a/orangewidget/workflow/tests/test_widgetsscheme.py
+++ b/orangewidget/workflow/tests/test_widgetsscheme.py
@@ -162,6 +162,7 @@ class TestWidgetScheme(GuiTest):
         model.sync_node_properties()
 
         model.clear()
+        model.set_report_view(None)
 
 
 class TestWidgetManager(GuiTest):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Orange3 CI tests on macOS frequently stall with something like:

```
test_browse_for_missing (Orange.widgets.data.tests.test_owcsvimport.TestOWCSVFileImport) ... ok
test_browse_for_missing_prefixed (Orange.widgets.data.tests.test_owcsvimport.TestOWCSVFileImport) ... ok
test_browse_prefix (Orange.widgets.data.tests.test_owcsvimport.TestOWCSVFileImport) ... ok
test_browse_prefix_parent (Orange.widgets.data.tests.test_owcsvimport.TestOWCSVFileImport) ... ok
test_minimum_size (Orange.widgets.data.tests.test_owcsvimport.TestOWCSVFileImport) ... ok
test_msg_base_class (Orange.widgets.data.tests.test_owcsvimport.TestOWCSVFileImport) ... ok
test_restore (Orange.widgets.data.tests.test_owcsvimport.TestOWCSVFileImport) ... js: Uncaught TypeError: Cannot read property 'id' of undefined
##[error]The operation was canceled.
```

I can duplicate this on macOS with:
```bash
python -m unittest -v Orange.widgets.data.tests.test_owcorrelations Orange.widgets.data.tests.test_owcreateclass Orange.widgets.data.tests.test_owcsvimport
```
This stalls once in about every 3 attempts.

##### Description of changes

Avoid use of `WebView.evalJS`  which calls `QApplication.processEvents.

Select and scroll to selected item in '<body onload=' for the initial selection. Use non waiting runJavaScript on subsequent user interactions.


Also some more of report cleanups similar to gh-37


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
