### PR TITLE
[FIX] io: Force matplotlib backend to pdf for the export

### DIFF
--- a/orangewidget/io.py
+++ b/orangewidget/io.py
@@ -261,8 +261,10 @@ class MatplotlibPDFFormat(MatplotlibFormat):
 
     @classmethod
     def write_image(cls, filename, scene):
-        code = scene_code(scene) + "\n\nplt.savefig({})".format(repr(filename))
-        exec(code, {})  # will generate a pdf
+        import matplotlib
+        with matplotlib.rc_context({"backend": "pdf"}):
+            code = scene_code(scene) + "\n\nplt.savefig({})".format(repr(filename))
+            exec(code, {})  # will generate a pdf
 
 
 if QtCore.QT_VERSION >= 0x050C00:  # Qt 5.12+


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Tests frequently segfault at process exit e.g. https://travis-ci.org/github/biolab/orange-widget-base/jobs/709922527#L673
One reason for this is  that matplotlib export test creates a qt window which might be destroyed after the QApplication

##### Description of changes

Force matplotlib backend to pdf for the export

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
