### PR TITLE
CallFrontComboBox: change logs into warnings

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -1490,6 +1490,7 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
             combo.addItem(str(item))
 
     if value:
+        combo.setObjectName(value)
         cindex = getdeepattr(master, value)
         if model is not None:
             combo.setModel(model)
@@ -1902,8 +1903,12 @@ class CallFrontComboBox(ControlledCallFront):
             try:
                 index = items.index(value or self.emptyString)
             except ValueError:
-                log.warning("Unable to set '{}' to '{}'; valid values are '{}'".
-                            format(self.control, value, ", ".join(items)))
+                if items:
+                    msg = f"Combo '{combo.objectName()}' has no item '{value}'; " \
+                          f"current items are {', '.join(map(repr, items))}."
+                else:
+                    msg = f"combo '{combo.objectName()}' is empty."
+                warnings.warn(msg, stacklevel=5)
             else:
                 self.control.setCurrentIndex(index)
 
@@ -1911,8 +1916,13 @@ class CallFrontComboBox(ControlledCallFront):
             if value < combo.count():
                 combo.setCurrentIndex(value)
             else:
-                log.warning("Unable to set '{}' to {}; largest index is {}".
-                            format(combo, value, combo.count() - 1))
+                if combo.count():
+                    msg = f"index {value} is out of range " \
+                          f"for combo box '{combo.objectName()}' " \
+                          f"with {combo.count()} item(s)."
+                else:
+                    msg = f"combo box '{combo.objectName()}' is empty."
+                warnings.warn(msg, stacklevel=5)
 
         combo = self.control
         if isinstance(value, int):


### PR DESCRIPTION
Messages like `Unable to set '<orangewidget.utils.combobox.ComboBoxSearch object at 0x7f133c789ee8>' to 0; largest index is -1` should be warnings for easier debugging and potential silencing.