### PR TITLE
Remove warning that excepthook has already been overridden

### DIFF
--- a/orangewidget/tests/utils.py
+++ b/orangewidget/tests/utils.py
@@ -139,11 +139,6 @@ def excepthook_catch(raise_on_exit=True):
     [(<class 'ZeroDivisionError'>, ZeroDivisionError('division by zero',), ...
     """
     excepthook = sys.excepthook
-    if excepthook != sys.__excepthook__:
-        warnings.warn(
-            "sys.excepthook was already patched (is {})"
-            "(just thought you should know this)".format(excepthook),
-            RuntimeWarning, stacklevel=2)
     seen = []
 
     def excepthook_handle(exctype, value, traceback):


### PR DESCRIPTION
This is now the prevalent warning in tests. As written by @ales-erjavec in https://github.com/biolab/orange3/pull/4961, it can be removed.