### PR TITLE
listview: Account for transient scroll bars in layout

### DIFF
--- a/orangewidget/utils/listview.py
+++ b/orangewidget/utils/listview.py
@@ -1,6 +1,6 @@
 from typing import Iterable
 
-from PyQt5.QtWidgets import QListView, QLineEdit
+from PyQt5.QtWidgets import QListView, QLineEdit, QStyle
 from PyQt5.QtGui import QResizeEvent
 from PyQt5.QtCore import (
     Qt,
@@ -129,8 +129,10 @@ class ListViewSearch(QListView):
         size = self.size()
         margins.setTop(sh.height())
         vscroll = self.verticalScrollBar()
+        style = self.style()
+        transient = style.styleHint(QStyle.SH_ScrollBar_Transient, None, vscroll)
         w = size.width()
-        if vscroll.isVisibleTo(self):
+        if vscroll.isVisibleTo(self) and not transient:
             w = w - vscroll.width() - 1
         search.setGeometry(0, 0, w, sh.height())
         self.setViewportMargins(margins)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

ListViewSearch does not account for transient scroll bars in line edit layout.

<img width="132" alt="Screenshot 2020-09-07 at 10 09 50" src="https://user-images.githubusercontent.com/4716745/92364441-5f036a80-f0f3-11ea-9090-d2f2b716d850.png">

Fixup for gh-85

##### Description of changes

* Account for transient scroll bars



##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
