### PR TITLE
[FIX] Tests: Cleanup created widgets

### DIFF
--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -163,6 +163,8 @@ class GuiTest(unittest.TestCase):
         """
         global app
         if app is None:
+            app = QApplication.instance()
+        if app is None:
             app = QApplication(["-", "-widgetcount"])
 
         # Disable App Nap on macOS (see

--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -232,15 +232,20 @@ class WidgetTest(GuiTest):
 
         cls.signal_manager = DummySignalManager()
 
-        report = OWReport()
-        cls.widgets.append(report)
+        report = None
+
+        def get_instance():
+            nonlocal report
+            if report is None:
+                report = OWReport()
+                if not (os.environ.get("TRAVIS") or os.environ.get("APPVEYOR")):
+                    report.show = Mock()
+                cls.widgets.append(report)
+            return report
 
         cls.tear_down_stack.enter_context(
-            patch.object(OWReport, "get_instance", lambda: report)
+            patch.object(OWReport, "get_instance", get_instance)
         )
-
-        if not (os.environ.get("TRAVIS") or os.environ.get("APPVEYOR")):
-            report.show = Mock()
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -242,6 +242,7 @@ class WidgetTest(GuiTest):
 
     @classmethod
     def tearDownClass(cls) -> None:
+        del cls.signal_manager
         widgets = cls.widgets[:]
         cls.widgets.clear()
         while widgets:

--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -90,6 +90,9 @@ class DummySignalManager:
     def __init__(self):
         self.outputs = {}
 
+    def clear(self):
+        self.outputs.clear()
+
     def send(self, widget, signal_name, value, id):
         if not isinstance(signal_name, str):
             signal_name = signal_name.name
@@ -249,6 +252,7 @@ class WidgetTest(GuiTest):
 
     @classmethod
     def tearDownClass(cls) -> None:
+        cls.signal_manager.clear()
         del cls.signal_manager
         widgets = cls.widgets[:]
         cls.widgets.clear()
@@ -258,10 +262,12 @@ class WidgetTest(GuiTest):
                 w.onDeleteWidget()
             if not sip.isdeleted(w):
                 w.deleteLater()
+            w.signalManager = None
         super().tearDownClass()
 
     def tearDown(self):
         """Process any pending events before the next test is executed."""
+        self.signal_manager.clear()
         QTest.qWait(0)
         super().tearDown()
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref: https://github.com/biolab/orange3/issues/4952

##### Description of changes

* Dispose of widgets created via create_widget helper. This used to be done but then removed in favor of `sip.setdestroyonexit(False)`  (https://github.com/biolab/orange3/issues/1791). However in PyQt5 5.15.0 this does not seem to have any effect.
* Cleanup the dummy signal_manager

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
