### PR TITLE
Import Sequence from typing, not collections

### DIFF
--- a/orangewidget/utils/itemmodels.py
+++ b/orangewidget/utils/itemmodels.py
@@ -1,4 +1,5 @@
-from collections import defaultdict, Sequence
+from collections import defaultdict
+from typing import Sequence
 from math import isnan, isinf
 from numbers import Number, Integral
 


### PR DESCRIPTION
##### Issue

*Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working.*
