### PR TITLE
widget: Set in/out msg text to - on no input/output

### DIFF
--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -1631,7 +1631,8 @@ class StateInfo(QObject):
         elif isinstance(summary, StateInfo.Summary):
             assert_single_arg()
             if isinstance(summary, StateInfo.Empty):
-                summary = summary.updated(details="No data on input")
+                summary = summary.updated(details="No data on input",
+                                          brief='-')
             if summary.icon.isNull():
                 summary = summary.updated(icon=summary.default_icon("input"))
         elif isinstance(summary, str):
@@ -1688,7 +1689,8 @@ class StateInfo(QObject):
         elif isinstance(summary, StateInfo.Summary):
             assert_single_arg()
             if isinstance(summary, StateInfo.Empty):
-                summary = summary.updated(details="No data on output")
+                summary = summary.updated(details="No data on output",
+                                          brief='-')
             if summary.icon.isNull():
                 summary = summary.updated(icon=summary.default_icon("output"))
         elif isinstance(summary, str):


### PR DESCRIPTION
##### Issue
I previously submitted #47, which was rejected at a meeting – I assume due to zero != null?

I still think it looks ugly to not have any text next to the empty in/out icon. If not a zero, how about a minus sign?

##### Changes
<img width="752" alt="Screenshot 2020-09-22 at 19 00 02" src="https://user-images.githubusercontent.com/24586651/93913767-d517ec00-fd05-11ea-84c1-6101d3054e5a.png">

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
