### PR TITLE
Revert "widget: Set in/out msg text to - on no input/output"

### DIFF
--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -1631,8 +1631,7 @@ class StateInfo(QObject):
         elif isinstance(summary, StateInfo.Summary):
             assert_single_arg()
             if isinstance(summary, StateInfo.Empty):
-                summary = summary.updated(details="No data on input",
-                                          brief='-')
+                summary = summary.updated(details="No data on input")
             if summary.icon.isNull():
                 summary = summary.updated(icon=summary.default_icon("input"))
         elif isinstance(summary, str):
@@ -1689,8 +1688,7 @@ class StateInfo(QObject):
         elif isinstance(summary, StateInfo.Summary):
             assert_single_arg()
             if isinstance(summary, StateInfo.Empty):
-                summary = summary.updated(details="No data on output",
-                                          brief='-')
+                summary = summary.updated(details="No data on output")
             if summary.icon.isNull():
                 summary = summary.updated(icon=summary.default_icon("output"))
         elif isinstance(summary, str):


### PR DESCRIPTION
Reverts biolab/orange-widget-base#98.

This PR crashes the "future compatibility" tests on Orange. We need to either change Orange's tests to accept both, "" and "-", change the tests to accept "-" and merge this PR just before release.