### PR TITLE
Revert "Revert "widget: Set in/out msg text to - on no input/output""

### DIFF
--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -1631,7 +1631,8 @@ class StateInfo(QObject):
         elif isinstance(summary, StateInfo.Summary):
             assert_single_arg()
             if isinstance(summary, StateInfo.Empty):
-                summary = summary.updated(details="No data on input")
+                summary = summary.updated(details="No data on input",
+                                          brief='-')
             if summary.icon.isNull():
                 summary = summary.updated(icon=summary.default_icon("input"))
         elif isinstance(summary, str):
@@ -1688,7 +1689,8 @@ class StateInfo(QObject):
         elif isinstance(summary, StateInfo.Summary):
             assert_single_arg()
             if isinstance(summary, StateInfo.Empty):
-                summary = summary.updated(details="No data on output")
+                summary = summary.updated(details="No data on output",
+                                          brief='-')
             if summary.icon.isNull():
                 summary = summary.updated(icon=summary.default_icon("output"))
         elif isinstance(summary, str):


### PR DESCRIPTION
Reverts biolab/orange-widget-base#99 (unreverts #98).

Merge just before release of this package and release of *Orange3*, and then merge biolab/orange3#5002.