### PR TITLE
Rework left side for better scrollbars and static buttonsArea

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -2861,7 +2861,7 @@ class VerticalScrollArea(QScrollArea):
         if not self.widget():
             return super().sizeHint()
 
-        width = self.widget().width()
+        width = self.widget().sizeHint().width()
         sb = self.verticalScrollBar()
         isTransient = sb.style().styleHint(QStyle.SH_ScrollBar_Transient, widget=sb)
         if not isTransient and sb.maximum() != sb.minimum():


### PR DESCRIPTION
Check this out with biolab/orange3#5013.

##### Issue
Current implementation shows/hides scrollbar each time it's shown, this is distracting.

Also, it'd be nice to have some buttons always visible in widgets (e.g., data projection controls), regardless of scroll position.

<img width="941" alt="Screenshot 2020-10-02 at 23 48 00" src="https://user-images.githubusercontent.com/24586651/94972522-b71e6880-0509-11eb-9c38-c315ab559256.png">

##### Description of changes
Implements a solution similar to the one in biolab/orange-canvas-core#122, making it dynamically update the scroll area's width when scrollbars are disabled/enabled, and when the window is large enough vertically to not show the scrollbar. Therefore, the left side can always be encapsulated in a VerticalScrollArea, making `left_side_scrolling` obsolete.

Also, the buttonsArea was now docked below a scrollable controlsArea. This change deprecates `buttons_area_orientation`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
