### PR TITLE
[FIX] FontModel: Fix 'Reset' for model based combos

### DIFF
--- a/orangewidget/utils/tests/test_visual_settings_dlg.py
+++ b/orangewidget/utils/tests/test_visual_settings_dlg.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 from AnyQt.QtWidgets import QComboBox, QCheckBox, QSpinBox, QLineEdit
 
 from orangewidget.tests.base import GuiTest
-from orangewidget.utils.visual_settings_dlg import SettingsDialog
+from orangewidget.utils.visual_settings_dlg import SettingsDialog, FontList
 
 
 class TestSettingsDialog(GuiTest):
@@ -15,6 +15,7 @@ class TestSettingsDialog(GuiTest):
                 "P2": (range(3, 10, 2), 5),
                 "P3": (None, True),
                 "P4": (None, "Foo Bar"),
+                "P5": (FontList([".Foo", ".Bar"]), ".Foo"),
             }}
         }
         self.dlg = SettingsDialog(None, self.defaults)
@@ -30,16 +31,19 @@ class TestSettingsDialog(GuiTest):
         self.assertIsInstance(controls[("Box", "Items", "P2")][0], QSpinBox)
         self.assertIsInstance(controls[("Box", "Items", "P3")][0], QCheckBox)
         self.assertIsInstance(controls[("Box", "Items", "P4")][0], QLineEdit)
+        self.assertIsInstance(controls[("Box", "Items", "P5")][0], QComboBox)
 
     def test_changed_settings(self):
         self.dialog_controls[("Box", "Items", "P1")][0].setCurrentText("Foo")
         self.dialog_controls[("Box", "Items", "P2")][0].setValue(7)
         self.dialog_controls[("Box", "Items", "P3")][0].setChecked(False)
         self.dialog_controls[("Box", "Items", "P4")][0].setText("Foo Baz")
+        self.dialog_controls[("Box", "Items", "P5")][0].setCurrentIndex(1)
         changed = {("Box", "Items", "P1"): "Foo",
                    ("Box", "Items", "P2"): 7,
                    ("Box", "Items", "P3"): False,
-                   ("Box", "Items", "P4"): "Foo Baz"}
+                   ("Box", "Items", "P4"): "Foo Baz",
+                   ("Box", "Items", "P5"): ".Bar"}
         self.assertDictEqual(self.dlg.changed_settings, changed)
 
     def test_reset(self):
@@ -48,6 +52,7 @@ class TestSettingsDialog(GuiTest):
         ctrls[("Box", "Items", "P2")][0].setValue(7)
         ctrls[("Box", "Items", "P3")][0].setChecked(False)
         ctrls[("Box", "Items", "P4")][0].setText("Foo Baz")
+        self.dialog_controls[("Box", "Items", "P5")][0].setCurrentIndex(1)
 
         self.dlg._SettingsDialog__reset()
         self.assertDictEqual(self.dlg.changed_settings, {})
@@ -55,6 +60,7 @@ class TestSettingsDialog(GuiTest):
         self.assertEqual(ctrls[("Box", "Items", "P2")][0].value(), 5)
         self.assertTrue(ctrls[("Box", "Items", "P3")][0].isChecked())
         self.assertEqual(ctrls[("Box", "Items", "P4")][0].text(), "Foo Bar")
+        self.assertEqual(ctrls[("Box", "Items", "P5")][0].currentText(), "Foo")
 
     def test_setting_changed(self):
         handler = Mock()
@@ -67,18 +73,22 @@ class TestSettingsDialog(GuiTest):
         handler.assert_called_with(('Box', 'Items', 'P3'), False)
         self.dialog_controls[("Box", "Items", "P4")][0].setText("Foo Baz")
         handler.assert_called_with(('Box', 'Items', 'P4'), "Foo Baz")
+        self.dialog_controls[("Box", "Items", "P5")][0].setCurrentIndex(1)
+        handler.assert_called_with(('Box', 'Items', 'P5'), ".Bar")
 
     def test_apply_settings(self):
         changed = [(("Box", "Items", "P1"), "Foo"),
                    (("Box", "Items", "P2"), 7),
                    (("Box", "Items", "P3"), False),
-                   (("Box", "Items", "P4"), "Foo Baz")]
+                   (("Box", "Items", "P4"), "Foo Baz"),
+                   (("Box", "Items", "P5"), ".Bar")]
         self.dlg.apply_settings(changed)
         ctrls = self.dialog_controls
         self.assertEqual(ctrls[("Box", "Items", "P1")][0].currentText(), "Foo")
         self.assertEqual(ctrls[("Box", "Items", "P2")][0].value(), 7)
         self.assertFalse(ctrls[("Box", "Items", "P3")][0].isChecked())
         self.assertEqual(ctrls[("Box", "Items", "P4")][0].text(), "Foo Baz")
+        self.assertEqual(ctrls[("Box", "Items", "P5")][0].currentText(), "Bar")
         self.assertDictEqual(self.dlg.changed_settings,
                              {k: v for k, v in changed})
 

--- a/orangewidget/utils/visual_settings_dlg.py
+++ b/orangewidget/utils/visual_settings_dlg.py
@@ -2,14 +2,13 @@ import sys
 from typing import List, Iterable, Tuple, Callable, Union, Dict
 from functools import singledispatch
 
-from AnyQt.QtCore import Qt, pyqtSignal as Signal, QStringListModel
+from AnyQt.QtCore import Qt, pyqtSignal as Signal, QStringListModel, \
+    QAbstractItemModel
 from AnyQt.QtWidgets import QDialog, QVBoxLayout, QComboBox, QCheckBox, \
-    QDialogButtonBox, QSpinBox, QWidget, QGroupBox, QApplication, \
-    QFormLayout, QLineEdit
+    QDialogButtonBox, QSpinBox, QWidget, QApplication, QFormLayout, QLineEdit
 
 from orangewidget import gui
 from orangewidget.utils.combobox import _ComboBoxListDelegate
-from orangewidget.utils.itemmodels import PyListModel
 from orangewidget.widget import OWBaseWidget
 
 KeyType = Tuple[str, str, str]
@@ -173,7 +172,7 @@ def _(values: FontList, value: str, key: KeyType, signal: Callable) \
                 return "separator"
 
             value = super().data(index, role)
-            if role in (Qt.DisplayRole, Qt.EditRole) and value.startswith("."):
+            if role == Qt.DisplayRole and value.startswith("."):
                 value = value[1:]
             return value
 
@@ -222,7 +221,10 @@ def _set_control_value(*_):
 
 @_set_control_value.register(QComboBox)
 def _(combo: QComboBox, value: str):
-    combo.setCurrentText(value)
+    model: QAbstractItemModel = combo.model()
+    values = [model.data(model.index(i, 0), role=Qt.EditRole)
+              for i in range(model.rowCount())]
+    combo.setCurrentIndex(values.index(value))
 
 
 @_set_control_value.register(QSpinBox)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
On Visual settings dialog Font family does not reset after clicking Reset button.
Besides, saved setting (a font family with '.' prepended) does not apply, when opening a workflow.

##### Description of changes
Enable reseting combo boxes that use custom models as data source.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
