### PR TITLE
Reorganize OWBaseWidget

### DIFF
--- a/doc/source/widget.rst
+++ b/doc/source/widget.rst
@@ -69,7 +69,7 @@ of its corresponding handler method, which accepts the inputs at runtime:
 
         def commit(self):
             """Commit/send the outputs"""
-            sef.Outputs.sum.send("self.A + self.B)
+            sef.Outputs.sum.send(self.A + self.B)
 
 
 .. seealso:: :doc:`Getting Started Tutorial <tutorial>`

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -377,7 +377,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             return None
         properties = {name: getattr(cls, name) for name in
                       ("name", "icon", "description", "priority", "keywords",
-                       "replaces", "short_name")}
+                       "replaces", "short_name", "category")}
         properties["id"] = cls.id or cls.__module__
         properties["inputs"] = cls.get_signals("inputs")
         properties["outputs"] = cls.get_signals("outputs")

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -87,81 +87,166 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                    WidgetMessagesMixin, WidgetSignalsMixin,
                    metaclass=WidgetMetaClass, openclass=True):
     """
-    Base widget class in an orange widget workflow.
+    Base widget class in an Orange widget workflow.
     """
 
-    # Global widget count
-    widget_id = 0
-
-    # Widget Meta Description
-    # -----------------------
-
-    #: Widget name (:class:`str`) as presented in the Canvas
+    #: Widget name, as presented in the Canvas.
     name = None
-    short_name = None
-    id = None
-    category = None
-    version = None
-    #: Short widget description (:class:`str` optional), displayed in
-    #: canvas help tooltips.
+
+    #: Short widget description, displayed in canvas help tooltips.
     description = ""
-    #: Widget icon path relative to the defining module
+
+    #: Widget icon path, relative to the defining module.
     icon = "icons/Unknown.png"
-    #: Widget priority used for sorting within a category
-    #: (default ``sys.maxsize``).
-    priority = sys.maxsize
 
-    help = None
-    help_ref = None
-    url = None
-    keywords = []
-    background = None
-    replaces = None
+    class Inputs:
+        """
+        Define inputs in this nested class as class variables.
+        (type `orangewidget.widget.Input`)
 
-    #: A list of published input definitions
-    inputs = []
-    #: A list of published output definitions
-    outputs = []
+        Example::
 
-    # Default widget GUI layout settings
-    # ----------------------------------
+            class Inputs:
+                data = Input("Data", Table)
 
-    #: Should the widget have basic layout
-    #: (If this flag is false then the `want_main_area` and
-    #: `want_control_area` are ignored).
+        Then, register input handler methods with decorators.
+
+        Example::
+
+            @Inputs.data
+            def handle_data(self, data):
+                self.my_data = data
+        """
+
+    class Outputs:
+        """
+        Define outputs in this nested class as class variables.
+        (type `orangewidget.widget.Output`)
+
+        Example::
+
+            class Outputs:
+                data = Output("Data", Table)
+
+        Then, send results to the output with its `send` method.
+
+        Example::
+
+            def commit(self):
+                self.Outputs.data.send(self.my_data)
+        """
+
+    # -------------------------------------------------------------------------
+    # Widget GUI Layout Settings
+    # -------------------------------------------------------------------------
+
+    #: Should the widget have basic layout?
+    #: (if not, the rest of the GUI layout settings are ignored)
     want_basic_layout = True
-    #: Should the widget construct a `mainArea` (this is a resizable
-    #: area to the right of the `controlArea`).
-    want_main_area = True
-    #: Should the widget construct a `controlArea`.
+
+    #: Should the widget construct a `controlArea`?
     want_control_area = True
+
+    #: Should the widget construct a `mainArea`?
+    #: (a resizable area to the right of the `controlArea`)
+    want_main_area = True
+
+    #: Should the widget construct a `message_bar`?
+    #: (if not, make sure you show warnings/errors in some other way)
+    want_message_bar = True
+
+    #: Should the widget's window be resizeable?
+    #: (if not, the widget will derive a fixed size constraint from its layout)
+    resizing_enabled = True
+
+    #: Should the widget remember its window position/size?
+    save_position = True
+
     #: Is vertical scrolling on the widget's left side, which usually
     #: contains  the `controlArea`, allowed?
     left_side_scrolling = False
+
     #: Orientation of the buttonsArea box; valid only if
     #: `want_control_area` is `True`. Possible values are Qt.Horizontal,
     #: Qt.Vertical and None for no buttons area
     buttons_area_orientation = Qt.Horizontal
-    #: Specify whether the default message bar widget should be created
-    #: and placed into the default layout. If False then clients are
-    #: responsible for displaying messages within the widget in an
-    #: appropriate manner.
-    want_message_bar = True
+
+    #: A list of advice messages to display to the user.
+    #: (when a widget is first shown a message from this list is selected
+    #: for display. If a user accepts (clicks 'Ok. Got it') the choice is
+    #: recorded and the message is never shown again (closing the message
+    #: will not mark it as seen). Messages can be displayed again by pressing
+    #: Shift + F1)
+    UserAdviceMessages = []
+
+    # -------------------------------------------------------------------------
+    # Miscellaneous Options
+    # -------------------------------------------------------------------------
+
+    #: Version of the settings representation
+    #: (subclasses should increase this number when they make breaking
+    #: changes to settings representation (a settings that used to store
+    #: int now stores string) and handle migrations in migrate and
+    #: migrate_context settings)
+    settings_version = 1
+
+    #: Signal emitted before settings are packed and saved.
+    #: (gives you a chance to sync state to Setting values)
+    settingsAboutToBePacked = Signal()
+
+    #: Settings handler, can be overridden for context handling.
+    settingsHandler: SettingsHandler = None
+
+    #: Widget keywords, used for finding it in the quick menu.
+    keywords = []
+
+    #: Widget priority, used for sorting within a category.
+    priority = sys.maxsize
+
+    #: Short name for widget, displayed in toolbox.
+    #: (set this if the widget's conventional name is long)
+    short_name = None
+
+    #: A list of widget IDs that this widget replaces in older workflows.
+    replaces = None
+
     #: Widget painted by `Save graph` button
     graph_name = None
     graph_writers = [f for f in ImgFormat.formats
                      if getattr(f, 'write_image', None)
                      and getattr(f, "EXTENSIONS", None)]
 
-    save_position = True
+    #: Explicitly set widget category,
+    #: should it not already be part of a package.
+    category = None
+    version = None
+    help = None
+    help_ref = None
+    url = None
+    background = None
 
-    #: If false the widget will receive fixed size constraint
-    #: (derived from it's layout). Use for widgets which have simple
-    #: static size contents.
-    resizing_enabled = True
+    # -------------------------------------------------------------------------
+    # Private Interface
+    # -------------------------------------------------------------------------
 
-    blockingStateChanged = Signal(bool)
-    processingStateChanged = Signal(int)
+    # Global widget count
+    widget_id = 0
+
+    # Custom widget id, kept for backward compatibility
+    id = None
+
+    # A list of published input definitions.
+    # (conventionally generated from Inputs nested class)
+    inputs = []
+
+    # A list of published output definitions.
+    # (conventionally generated from Outputs nested class)
+    outputs = []
+
+    contextAboutToBeOpened = Signal(object)
+    contextOpened = Signal()
+    contextClosed = Signal()
+    openVisualSettingsClicked = Signal()
 
     # Signals have to be class attributes and cannot be inherited,
     # say from a mixin. This has something to do with the way PyQt binds them
@@ -169,34 +254,8 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     messageActivated = Signal(Msg)
     messageDeactivated = Signal(Msg)
 
-    settingsHandler = None
-    """:type: SettingsHandler"""
-
-    #: Version of the settings representation
-    #: Subclasses should increase this number when they make breaking
-    #: changes to settings representation (a settings that used to store
-    #: int now stores string) and handle migrations in migrate and
-    #: migrate_context settings.
-    settings_version = 1
-
     savedWidgetGeometry = settings.Setting(None)
     controlAreaVisible = settings.Setting(True, schema_only=True)
-
-    #: A list of advice messages (:class:`Message`) to display to the user.
-    #: When a widget is first shown a message from this list is selected
-    #: for display. If a user accepts (clicks 'Ok. Got it') the choice is
-    #: recorded and the message is never shown again (closing the message
-    #: will not mark it as seen). Messages can be displayed again by pressing
-    #: Shift + F1
-    #:
-    #: :type: list of :class:`Message`
-    UserAdviceMessages = []
-
-    settingsAboutToBePacked = Signal()
-    contextAboutToBeOpened = Signal(object)
-    contextOpened = Signal()
-    contextClosed = Signal()
-    openVisualSettingsClicked = Signal()
 
     # pylint: disable=protected-access, access-member-before-definition
     def __new__(cls, *args, captionTitle=None, **kwargs):
@@ -1113,6 +1172,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
     widgetStateChanged = Signal()
     blockingStateChanged = Signal(bool)
+    processingStateChanged = Signal(int)
     invalidatedStateChanged = Signal(bool)
     readyStateChanged = Signal(bool)
 

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -250,12 +250,6 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     #: should it not already be part of a package.
     category: str = None
 
-    version = None
-    help = None
-    help_ref = None
-    url = None
-    background = None
-
     # -------------------------------------------------------------------------
     # Private Interface
     # -------------------------------------------------------------------------
@@ -383,8 +377,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             return None
         properties = {name: getattr(cls, name) for name in
                       ("name", "icon", "description", "priority", "keywords",
-                       "help", "help_ref", "url",
-                       "version", "background", "replaces", "short_name")}
+                       "replaces", "short_name")}
         properties["id"] = cls.id or cls.__module__
         properties["inputs"] = cls.get_signals("inputs")
         properties["outputs"] = cls.get_signals("outputs")

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -6,7 +6,7 @@ import textwrap
 from operator import attrgetter
 from math import log10
 
-from typing import Optional, Union
+from typing import Optional, Union, List
 
 from AnyQt.QtWidgets import (
     QWidget, QDialog, QVBoxLayout, QSizePolicy, QApplication, QStyle,
@@ -45,6 +45,36 @@ __all__ = [
     "OWBaseWidget", "Input", "Output", "AttributeList", "Message", "Msg",
     "StateInfo",
 ]
+
+
+class Message:
+    """
+    A user message.
+
+    :param str text: Message text
+    :param str persistent_id:
+        A persistent message id.
+    :param icon: Message icon
+    :type icon: QIcon or QStyle.StandardPixmap
+    :param str moreurl:
+        An url to open when a user clicks a 'Learn more' button.
+
+    .. seealso:: :const:`OWBaseWidget.UserAdviceMessages`
+    """
+    #: QStyle.SP_MessageBox* pixmap enums repeated for easier access
+    Question = QStyle.SP_MessageBoxQuestion
+    Information = QStyle.SP_MessageBoxInformation
+    Warning = QStyle.SP_MessageBoxWarning
+    Critical = QStyle.SP_MessageBoxCritical
+
+    def __init__(self, text, persistent_id, icon=None, moreurl=None):
+        assert isinstance(text, str)
+        assert isinstance(icon, (type(None), QIcon, QStyle.StandardPixmap))
+        assert persistent_id is not None
+        self.text = text
+        self.icon = icon
+        self.moreurl = moreurl
+        self.persistent_id = persistent_id
 
 
 def _asmappingproxy(mapping):
@@ -91,13 +121,13 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     """
 
     #: Widget name, as presented in the Canvas.
-    name = None
+    name: str = None
 
     #: Short widget description, displayed in canvas help tooltips.
-    description = ""
+    description: str = ""
 
     #: Widget icon path, relative to the defining module.
-    icon = "icons/Unknown.png"
+    icon: str = "icons/Unknown.png"
 
     class Inputs:
         """
@@ -177,7 +207,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     #: recorded and the message is never shown again (closing the message
     #: will not mark it as seen). Messages can be displayed again by pressing
     #: Shift + F1)
-    UserAdviceMessages = []
+    UserAdviceMessages: List[Message] = []
 
     # -------------------------------------------------------------------------
     # Miscellaneous Options
@@ -188,7 +218,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     #: changes to settings representation (a settings that used to store
     #: int now stores string) and handle migrations in migrate and
     #: migrate_context settings)
-    settings_version = 1
+    settings_version: int = 1
 
     #: Signal emitted before settings are packed and saved.
     #: (gives you a chance to sync state to Setting values)
@@ -198,27 +228,28 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     settingsHandler: SettingsHandler = None
 
     #: Widget keywords, used for finding it in the quick menu.
-    keywords = []
+    keywords: List[str] = []
 
     #: Widget priority, used for sorting within a category.
-    priority = sys.maxsize
+    priority: int = sys.maxsize
 
     #: Short name for widget, displayed in toolbox.
     #: (set this if the widget's conventional name is long)
-    short_name = None
+    short_name: str = None
 
     #: A list of widget IDs that this widget replaces in older workflows.
-    replaces = None
+    replaces: List[str] = None
 
     #: Widget painted by `Save graph` button
-    graph_name = None
-    graph_writers = [f for f in ImgFormat.formats
-                     if getattr(f, 'write_image', None)
-                     and getattr(f, "EXTENSIONS", None)]
+    graph_name: str = None
+    graph_writers: List[ImgFormat] = [f for f in ImgFormat.formats
+                                  if getattr(f, 'write_image', None)
+                                  and getattr(f, "EXTENSIONS", None)]
 
     #: Explicitly set widget category,
     #: should it not already be part of a package.
-    category = None
+    category: str = None
+
     version = None
     help = None
     help_ref = None
@@ -1454,36 +1485,6 @@ class _StatusBar(QStatusBar):
         style.drawPrimitive(QStyle.PE_PanelStatusBar, opt, painter, None)
         # Do not draw any PE_FrameStatusBarItem frames.
         painter.end()
-
-
-class Message:
-    """
-    A user message.
-
-    :param str text: Message text
-    :param str persistent_id:
-        A persistent message id.
-    :param icon: Message icon
-    :type icon: QIcon or QStyle.StandardPixmap
-    :param str moreurl:
-        An url to open when a user clicks a 'Learn more' button.
-
-    .. seealso:: :const:`OWBaseWidget.UserAdviceMessages`
-    """
-    #: QStyle.SP_MessageBox* pixmap enums repeated for easier access
-    Question = QStyle.SP_MessageBoxQuestion
-    Information = QStyle.SP_MessageBoxInformation
-    Warning = QStyle.SP_MessageBoxWarning
-    Critical = QStyle.SP_MessageBoxCritical
-
-    def __init__(self, text, persistent_id, icon=None, moreurl=None):
-        assert isinstance(text, str)
-        assert isinstance(icon, (type(None), QIcon, QStyle.StandardPixmap))
-        assert persistent_id is not None
-        self.text = text
-        self.icon = icon
-        self.moreurl = moreurl
-        self.persistent_id = persistent_id
 
 
 #: Input/Output flags (deprecated).


### PR DESCRIPTION
##### Description of changes
In an effort to make it easier to make a widget, I've reorganized OWBaseWidget a bit, separating it into four sections:
- Widget Metadata
- Widget GUI Layout Settings
- Miscellaneous Options
- Protected Interface

Really, the user should only be looking at the first three sections when creating a widget.


##### RFC
Are these options really used anywhere? Is there any reason to keep them?

```
category = None
version = None
help = None
help_ref = None
url = None
background = None
```

Something I'd love to do is change the default for `want_main_area` to `False`. I assume most people writing a custom widget won't be using the main area. But, this is probably too much of a backward compatibility hassle to do.

Also, is there anything wrong with changing defaults for parameters like `name` from `None` to `""`? As in, if it still evaluates to the same boolean value? I'm not quite sure how widget description generation works.