### PR TITLE
mainwindow: Fixup save report dialog UX

### DIFF
--- a/orangewidget/workflow/mainwindow.py
+++ b/orangewidget/workflow/mainwindow.py
@@ -193,17 +193,19 @@ class OWCanvasMainWindow(CanvasMainWindow):
         if not report.is_changed():
             return QDialog.Accepted
 
-        answ = QMessageBox(
+        mBox = QMessageBox(
             self,
             windowTitle="Report window",
             icon=QMessageBox.Question,
-            text="Report window contains unsaved changes",
-            informativeText="Save the report?",
-            standardButtons=QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,
-        ).exec()
+            text="The report contains unsaved changes.",
+            informativeText="Would you like to save the report?",
+            standardButtons=QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
+        )
+        mBox.setDefaultButton(QMessageBox.Save)
+        answ = mBox.exec()
         if answ == QMessageBox.Cancel:
             return QDialog.Rejected
-        if answ == QMessageBox.Yes:
+        if answ == QMessageBox.Save:
             return report.save_report()
         return QDialog.Accepted
 


### PR DESCRIPTION
Before:
<img width="513" alt="Screenshot 2020-10-11 at 15 33 18" src="https://user-images.githubusercontent.com/24586651/95680071-21549e80-0bd7-11eb-8c2d-a2894f1aee0c.png">
After:
<img width="524" alt="Screenshot 2020-10-11 at 15 33 02" src="https://user-images.githubusercontent.com/24586651/95680069-1ef24480-0bd7-11eb-9991-b791ebe08e09.png">

On a sidenote, does anyone actually use the report feature? How is it meant to be used?

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
