### PR TITLE
gui: Commit spin value on manual calls to setValue, expose backwards compatibility testing interface

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -20,7 +20,7 @@ from AnyQt.QtWidgets import (
     QTableWidgetItem, QStyledItemDelegate, QTableView, QHeaderView,
     QScrollArea, QLineEdit)
 
-from orangewidget.utils import getdeepattr
+from orangewidget.utils import getdeepattr, DeprecatedSignal
 from orangewidget.utils.buttons import VariableTextPushButton
 from orangewidget.utils.combobox import (
     ComboBox as OrangeComboBox, ComboBoxSearch as OrangeComboBoxSearch
@@ -619,6 +619,39 @@ class SpinBoxMixin:
         """
         super().setValue(value)
         self.commitValue()
+
+    """
+    Backwards Compatibility Test Interface
+    --------------------------------------
+
+    Spinboxes used to automatically commit on any change in value.
+    This meant it committed its value mid-typing/holding up or down, too.
+    In testing, spinbox settings were tested by either:
+      - calling setValue (most often)
+      - emitting its valueChanged signal (less often)
+      - calling setValue and then onEnter (least often)
+
+    I suggest keeping setValue calls as automatic value commits,
+    but deprecating the rest.
+    """
+
+    __original_init = __init__
+
+    def __init__(self, *args, **kwargs):
+        SpinBoxMixin.__original_init(self, *args, **kwargs)
+        self.valueChanged = DeprecatedSignal(
+            self.valueChanged,
+            warning_text="Testing by emitting a spinbox's 'valueChanged' signal is "
+                         "deprecated, use its 'setValue' method.",
+            emit_callback=self.setValue
+        )
+
+    def onEnter(self):
+        warnings.warn(
+            "Testing by by calling a spinbox's 'onEnter' method is deprecated, "
+            "use its 'setValue' method.",
+            DeprecationWarning
+        )
 
 
 class SpinBox(SpinBoxMixin, QtWidgets.QSpinBox):

--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -527,6 +527,9 @@ class SpinBoxMixin:
         # don't focus on scroll
         self.setFocusPolicy(Qt.StrongFocus)
 
+        self.cback = None
+        self.cfunc = None
+
     def onEditingFinished(self):
         """
         Commits the change by calling the appropriate callbacks.
@@ -578,7 +581,7 @@ class SpinBoxMixin:
             pos = event.globalPos()
             posVal = pos.y() if self.verticalDirection else -pos.x()
             valueOffset = (self.mouseStartPos - posVal) * self.stepSize
-            self.setValue(self.preDragValue + valueOffset)
+            super().setValue(self.preDragValue + valueOffset)
 
             event.accept()
             return True
@@ -608,6 +611,14 @@ class SpinBoxMixin:
                 self.preEditvalue = self.value()
                 self.textEditing = True
         return super().eventFilter(obj, event)
+
+    def setValue(self, value):
+        """
+        Manually calling setValue will commit the value.
+        Useful for testing.
+        """
+        super().setValue(value)
+        self.commitValue()
 
 
 class SpinBox(SpinBoxMixin, QtWidgets.QSpinBox):

--- a/orangewidget/utils/__init__.py
+++ b/orangewidget/utils/__init__.py
@@ -1,5 +1,6 @@
 import inspect
 import sys
+import warnings
 from operator import attrgetter
 
 from AnyQt.QtCore import QObject
@@ -64,3 +65,23 @@ def getmembers(obj, predicate=None):
     else:
         mypredicate = predicate
     return inspect.getmembers(obj, mypredicate)
+
+
+class DeprecatedSignal:
+    def __init__(self, actual_signal, *args,
+                 warning_text='Deprecated', emit_callback=None, **kwargs):
+        self.signal = actual_signal
+        self.warning_text = warning_text
+        self.emit_callback = emit_callback
+
+    def emit(self, *args, **kwargs):
+        warnings.warn(
+            self.warning_text,
+            DeprecationWarning, stacklevel=2
+        )
+        if self.emit_callback:
+            self.emit_callback(*args, **kwargs)
+        return self.signal.emit(*args, **kwargs)
+
+    def __getattr__(self, item):
+        return self.__signal.item


### PR DESCRIPTION
##### Issue
This PR fixes the failing Orange3 future-compatibility tests.

Spinboxes used to automatically commit on any change in value. This meant it committed its value mid-typing/holding up or down, too.
In testing, spinbox settings were tested by either:
- calling setValue (most often)
- emitting its valueChanged signal (less often)
- calling setValue and then onEnter (least often)

Just calling `setValue` propagates the changes, but does not trigger callbacks/callfronts.

##### Description of changes
This PR makes setValue work for testing, and deprecates the other two methods of testing. A call to `setValue` will now also trigger callbacks/callfronts.

https://github.com/biolab/orange3/pull/4995 fixes the deprecations, and raises the orange-widget-base version.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
