### PR TITLE
visual_settings_dlg: Default to close button

### DIFF
--- a/orangewidget/utils/visual_settings_dlg.py
+++ b/orangewidget/utils/visual_settings_dlg.py
@@ -49,8 +49,13 @@ class SettingsDialog(QDialog):
             orientation=Qt.Horizontal,
             standardButtons=QDialogButtonBox.Close | QDialogButtonBox.Reset,
         )
-        buttons.button(QDialogButtonBox.Close).clicked.connect(self.close)
-        buttons.button(QDialogButtonBox.Reset).clicked.connect(self.__reset)
+        closeButton = buttons.button(QDialogButtonBox.Close)
+        closeButton.clicked.connect(self.close)
+
+        resetButton = buttons.button(QDialogButtonBox.Reset)
+        resetButton.clicked.connect(self.__reset)
+        resetButton.setAutoDefault(False)
+
         layout.addWidget(buttons)
 
         self.__initialize(settings)


### PR DESCRIPTION
##### Issue
Upon pressing enter in the visual setting dialog, Reset is invoked.

It's more intuitive to type in the title, and press enter to confirm it, rather than to reset it.

##### Description of changes
Makes the only autoDefault button Close.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
