### PR TITLE
[FIX] PDF export with pyqtgraph 0.11

### DIFF
--- a/orangewidget/tests/test_io.py
+++ b/orangewidget/tests/test_io.py
@@ -83,6 +83,25 @@ class TestPdf(GuiTest):
             imgio.PdfFormat.write(fname, graph)
             with open(fname, "rb") as f:
                 self.assertTrue(f.read().startswith(b'%PDF'))
+            size_empty = os.path.getsize(fname)
+        finally:
+            os.unlink(fname)
+
+        # does a ScatterPlotItem increases file size == is it drawn
+        graph = pyqtgraph.PlotWidget()
+        graph.addItem(pyqtgraph.ScatterPlotItem(x=list(range(100)), y=list(range(100))))
+        try:
+            imgio.PdfFormat.write(fname, graph)
+            self.assertGreater(os.path.getsize(fname), size_empty + 10000)
+        finally:
+            os.unlink(fname)
+
+        # does a PlotCurveItem increases file size == is it drawn
+        graph = pyqtgraph.PlotWidget()
+        graph.addItem(pyqtgraph.PlotCurveItem(x=list(range(100)), y=list(range(100))))
+        try:
+            imgio.PdfFormat.write(fname, graph)
+            self.assertGreater(os.path.getsize(fname), size_empty + 2000)
         finally:
             os.unlink(fname)
 

--- a/orangewidget/utils/PDFExporter.py
+++ b/orangewidget/utils/PDFExporter.py
@@ -28,6 +28,17 @@ class PDFExporter(Exporter):
             bg.setAlpha(0)
         self.background = bg
 
+        # The following code is a workaround for a bug in pyqtgraph 1.1. The suggested
+        # fix upstream was pyqtgraph/pyqtgraph#1458
+        try:
+            from pyqtgraph.graphicsItems.ViewBox.ViewBox import ChildGroup
+            for item in self.getPaintItems():
+                if isinstance(item, ChildGroup):
+                    if item.flags() & QGraphicsItem.ItemClipsChildrenToShape:
+                        item.setFlag(QGraphicsItem.ItemClipsChildrenToShape, False)
+        except:  # pylint: disable=bare-except
+            pass
+
     def export(self, filename=None):
         pw = QPdfWriter(filename)
         dpi = QApplication.desktop().logicalDpiX()


### PR DESCRIPTION
##### Issue
Fixes #111. 

##### Description of changes
Unsetting clipping before export in one pyqtgraph's object, a backport of pyqtgraph/pyqtgraph#1458

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
