### PR TITLE
messagewidget: For detailed msgs, show full msg on hover/click

### DIFF
--- a/orangewidget/utils/messagewidget.py
+++ b/orangewidget/utils/messagewidget.py
@@ -575,12 +575,10 @@ class MessagesWidget(QWidget):
         messages = [m for m in self.__messages.values() if not m.isEmpty()]
         if not messages:
             fulltext = ""
-        elif len(messages) > 1 or len(messages) == 1 and is_short(messages[0]):
+        else:
             messages = sorted(messages, key=attrgetter("severity"),
                               reverse=True)
             fulltext = "<hr/>".join(m.asHtml() for m in messages)
-        else:
-            fulltext = messages[0].asHtml(includeShortText=False)
         self.__fulltext = fulltext
         self.setToolTip(self.__styled(self.__defaultStyleSheet, fulltext))
         self.anim.start(QPropertyAnimation.KeepWhenStopped)


### PR DESCRIPTION
##### Issue
Some widgets are too small to display the entire error/warning. If the message has detailed text too, the title isn't shown in the popup/tooltip alongside it.
![Screenshot 2020-12-21 at 20 20 49](https://user-images.githubusercontent.com/24586651/102813981-17ff6380-43ca-11eb-8cd8-1de48cab0428.png)

##### Description of changes
![Screenshot 2020-12-21 at 20 19 22](https://user-images.githubusercontent.com/24586651/102813986-1b92ea80-43ca-11eb-90fb-64a194103d41.png)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
