### PR TITLE
widget: Stretch controlArea to buttonsArea

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -2854,10 +2854,13 @@ class VerticalScrollArea(QScrollArea):
 
     def resizeEvent(self, event):
         sb = self.verticalScrollBar()
-        if sb.minimum() == sb.maximum():
+        isTransient = sb.style().styleHint(QStyle.SH_ScrollBar_Transient, widget=sb)
+
+        if isTransient or sb.minimum() == sb.maximum():
             self.setViewportMargins(0, 0, 0, 0)
         else:
             self.setViewportMargins(0, 0, 5, 0)
+
         super().resizeEvent(event)
         self.updateGeometry()
         self.parent().updateGeometry()
@@ -2871,10 +2874,9 @@ class VerticalScrollArea(QScrollArea):
         isTransient = sb.style().styleHint(QStyle.SH_ScrollBar_Transient, widget=sb)
         if not isTransient and sb.maximum() != sb.minimum():
             width += sb.style().pixelMetric(QStyle.PM_ScrollBarExtent, widget=sb)
+            width += 5
 
         sh = self.widget().sizeHint()
-        if sb.minimum() != sb.maximum():
-            width += 5
         sh.setWidth(width)
         return sh
 

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -480,6 +480,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         if self.want_main_area:
             self.left_side.setSizePolicy(
                 QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
+            self.left_side.layout().setStretch(0, 9999999)
 
             scroll_area = VerticalScrollArea(self.left_side)
             scroll_area.setSizePolicy(QSizePolicy.MinimumExpanding,
@@ -488,10 +489,13 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                                         sizePolicy=(QSizePolicy.Fixed,
                                                     QSizePolicy.MinimumExpanding))
             scroll_area.setWidget(self.controlArea)
+
             self.left_side.layout().addWidget(scroll_area)
+
             m = 4, 4, 0, 4
         else:
             self.controlArea = gui.vBox(self.left_side, spacing=0)
+
             m = 4, 4, 4, 4
 
         if self.buttons_area_orientation is not None:

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -480,7 +480,6 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         if self.want_main_area:
             self.left_side.setSizePolicy(
                 QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
-            self.left_side.layout().setStretch(0, 9999999)
 
             scroll_area = VerticalScrollArea(self.left_side)
             scroll_area.setSizePolicy(QSizePolicy.MinimumExpanding,
@@ -491,6 +490,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             scroll_area.setWidget(self.controlArea)
 
             self.left_side.layout().addWidget(scroll_area)
+            self.left_side.layout().setStretch(0, 9999999)  # allow full stretch
 
             m = 4, 4, 0, 4
         else:

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -499,12 +499,13 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
         if self.buttons_area_orientation is not None:
             self._insert_buttons_area()
+            self.buttonsArea.layout().setContentsMargins(4, 4, 0, 4)
 
         self.controlArea.layout().setContentsMargins(*m)
 
     def _insert_buttons_area(self):
         self.buttonsArea = gui.widgetBox(
-            self.left_side, addSpace=0, spacing=9, margin=4,
+            self.left_side, addSpace=0, spacing=9,
             orientation=self.buttons_area_orientation,
             sizePolicy=(QSizePolicy.MinimumExpanding,
                         QSizePolicy.Maximum)

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -504,8 +504,6 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         self.controlArea.layout().setContentsMargins(*m)
 
     def _insert_buttons_area(self):
-        if self.want_main_area:
-            gui.rubber(self.left_side)
         self.buttonsArea = gui.widgetBox(
             self.left_side, addSpace=0, spacing=9, margin=4,
             orientation=self.buttons_area_orientation)

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -490,7 +490,6 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             scroll_area.setWidget(self.controlArea)
 
             self.left_side.layout().addWidget(scroll_area)
-            self.left_side.layout().setStretch(0, 9999999)  # allow full stretch
 
             m = 4, 4, 0, 4
         else:
@@ -506,7 +505,10 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     def _insert_buttons_area(self):
         self.buttonsArea = gui.widgetBox(
             self.left_side, addSpace=0, spacing=9, margin=4,
-            orientation=self.buttons_area_orientation)
+            orientation=self.buttons_area_orientation,
+            sizePolicy=(QSizePolicy.MinimumExpanding,
+                        QSizePolicy.Maximum)
+        )
 
     def _insert_main_area(self):
         self.mainArea = gui.vBox(


### PR DESCRIPTION
##### Issue
Fixes https://github.com/biolab/orange3/issues/5225


##### Description of changes
You're right @markotoplak, this works well for all widgets :D
Although, some more testing would be nice. Combine this PR with https://github.com/biolab/orange3/pull/5013

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
