### PR TITLE
gui: Set box title to " " by default

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -363,10 +363,30 @@ def widgetBox(widget, box=None, orientation=Qt.Vertical, margin=None, spacing=4,
     :return: Constructed box
     :rtype: QGroupBox or QWidget
     """
+    outer_box = None
     if box:
         b = QtWidgets.QGroupBox(widget)
         if isinstance(box, str):
             b.setTitle(" " + box.strip() + " ")
+        else:
+            b.setTitle(" ")
+
+            font = b.font()
+            original_size = font.pointSize()
+            font.setPointSize(1)
+            b.setFont(font)
+
+            b.setLayout(QtWidgets.QHBoxLayout())
+            b.layout().setContentsMargins(0, 0, 0, 0)
+
+            outer_box = b
+
+            b = QtWidgets.QGroupBox(widget)
+            b.setFlat(True)
+            font = b.font()
+            font.setPointSize(original_size)
+            b.setFont(font)
+
         if margin is None:
             margin = 7
     else:
@@ -374,11 +394,12 @@ def widgetBox(widget, box=None, orientation=Qt.Vertical, margin=None, spacing=4,
         b.setContentsMargins(0, 0, 0, 0)
         if margin is None:
             margin = 0
+    b.outer_box = outer_box or b
     setLayout(b, orientation)
     b.layout().setSpacing(spacing)
     b.layout().setContentsMargins(margin, margin, margin, margin)
     misc.setdefault('addSpace', bool(box))
-    miscellanea(b, None, widget, **misc)
+    miscellanea(b, outer_box, widget, **misc)
     return b
 
 
@@ -1721,13 +1742,14 @@ def auto_commit(widget, master, value, label, auto_label=None, box=True,
         else:
             auto_label = label.title() + " Automatically"
     if isinstance(box, QWidget):
-        b = box
+        outer_box = b = box
     else:
         if orientation is None:
             orientation = Qt.Vertical if checkbox_label else Qt.Horizontal
         b = widgetBox(widget, box=box, orientation=orientation,
                       addToLayout=False)
         b.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)
+        outer_box = b.outer_box
 
     b.checkbox = cb = checkBox(b, master, value, checkbox_label,
                                callback=checkbox_toggled, tooltip=auto_label)
@@ -1746,7 +1768,7 @@ def auto_commit(widget, master, value, label, auto_label=None, box=True,
     setattr(master, commit_name, unconditional_commit)
     misc['addToLayout'] = misc.get('addToLayout', True) and \
                           not isinstance(box, QtWidgets.QWidget)
-    miscellanea(b, widget, widget, **misc)
+    miscellanea(outer_box, widget, widget, **misc)
     return b
 
 


### PR DESCRIPTION
##### Issue
QGroupBoxes without titles have their top pixel shaved off, effectively not showing the box's top outline. Here's a gif of an unnamed box, a box named `' '`, and a named box:
![ezgif-2-8fed219b6530](https://user-images.githubusercontent.com/24586651/106541537-2200a000-64fa-11eb-8625-36a40368245e.gif)


##### Description of changes
This adds the tiniest bit of top margin, required to see the top outline of the box. Some weird (likely Mac-only) visual bug.

Someone please check this on Windows and Linux too, if it causes changes there, I'll `if sys.platform == 'darwin'` it.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
