### PR TITLE
Widget sizeHint, button/box sizePolicy fixes

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -231,10 +231,11 @@ def miscellanea(control, box, parent,
     :type sizePolicy: QSizePolicy
     """
     for prop, val in kwargs.items():
-        if prop == "sizePolicy":
-            control.setSizePolicy(QSizePolicy(*val))
+        method = getattr(control, "set" + prop[0].upper() + prop[1:])
+        if isinstance(val, tuple):
+            method(*val)
         else:
-            getattr(control, "set" + prop[0].upper() + prop[1:])(val)
+            method(val)
     if disabled:
         # if disabled==False, do nothing; it can be already disabled
         control.setDisabled(disabled)

--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -341,7 +341,7 @@ def rubber(widget):
     widget.layout().addStretch(100)
 
 
-def widgetBox(widget, box=None, orientation=Qt.Vertical, margin=None, spacing=4,
+def widgetBox(widget, box=None, orientation=Qt.Vertical, margin=None, spacing=None,
               **misc):
     """
     Construct a box with vertical or horizontal layout, and optionally,
@@ -378,7 +378,8 @@ def widgetBox(widget, box=None, orientation=Qt.Vertical, margin=None, spacing=4,
         if margin is None:
             margin = 0
     setLayout(b, orientation)
-    b.layout().setSpacing(spacing)
+    if spacing is not None:
+        b.layout().setSpacing(spacing)
     b.layout().setContentsMargins(margin, margin, margin, margin)
     miscellanea(b, None, widget, **misc)
     return b

--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -304,11 +304,13 @@ def _addSpace(widget, space):
         Otherwise, the default space is inserted by calling a :obj:`separator`.
     :type space: bool or int
     """
-    if space:
-        if type(space) == int:  # distinguish between int and bool!
-            separator(widget, space, space)
-        else:
-            separator(widget)
+    warnings.warn("'addSpace' has been deprecated. Use gui.separator instead.",
+                  DeprecationWarning, stacklevel=4)
+    # if space:
+    #     if type(space) == int:  # distinguish between int and bool!
+    #         separator(widget, space, space)
+    #     else:
+    #         separator(widget)
 
 
 def separator(widget, width=4, height=4):
@@ -368,7 +370,7 @@ def widgetBox(widget, box=None, orientation=Qt.Vertical, margin=None, spacing=4,
         if isinstance(box, str):
             b.setTitle(" " + box.strip() + " ")
         if margin is None:
-            margin = 7
+            margin = 4
     else:
         b = QtWidgets.QWidget(widget)
         b.setContentsMargins(0, 0, 0, 0)
@@ -377,7 +379,6 @@ def widgetBox(widget, box=None, orientation=Qt.Vertical, margin=None, spacing=4,
     setLayout(b, orientation)
     b.layout().setSpacing(spacing)
     b.layout().setContentsMargins(margin, margin, margin, margin)
-    misc.setdefault('addSpace', bool(box))
     miscellanea(b, None, widget, **misc)
     return b
 
@@ -1178,7 +1179,6 @@ def radioButtons(widget, master, value, btnLabels=(), tooltips=None,
         appendRadioButton(bg, lab, tooltip=tooltips and tooltips[i], id=i + 1)
     connectControl(master, value, callback, bg.group.buttonClicked[int],
                    CallFrontRadioButtons(bg), CallBackRadioButton(bg, master))
-    misc.setdefault('addSpace', bool(box))
     miscellanea(bg.group, bg, widget, **misc)
     return bg
 
@@ -1233,7 +1233,6 @@ def appendRadioButton(group, label, insertInto=None,
     if addToLayout:
         dest = insertInto or group
         dest.layout().addWidget(w, stretch)
-        _addSpace(dest, addSpace)
     return w
 
 

--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -909,10 +909,6 @@ def checkBox(widget, master, value, label, box=None,
     cbox.toggled[bool].connect(cbox.makeConsistent)
     cbox.makeConsistent(value)
     miscellanea(cbox, b, widget, **misc)
-
-    # QTBUG-2699
-    cbox.setAttribute(Qt.WA_LayoutUsesWidgetRect)
-
     return cbox
 
 
@@ -1112,10 +1108,6 @@ def button(widget, master, label, callback=None, width=None, height=None,
         button.clicked.connect(callback)
 
     miscellanea(button, None, widget, **misc)
-
-    # QTBUG-2699
-    button.setAttribute(Qt.WA_LayoutUsesWidgetRect)
-
     return button
 
 
@@ -1633,10 +1625,6 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
         log.warning("comboBox no longer accepts argument 'valueType'")
     miscellanea(combo, hb, widget, **misc)
     combo.emptyString = emptyString
-
-    # QTBUG-2699
-    combo.setAttribute(Qt.WA_LayoutUsesWidgetRect)
-
     return combo
 
 

--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -259,7 +259,9 @@ def miscellanea(control, box, parent,
     if sizePolicy is not None:
         if isinstance(sizePolicy, tuple):
             sizePolicy = QSizePolicy(*sizePolicy)
-        (box or control).setSizePolicy(sizePolicy)
+        if box:
+            box.setSizePolicy(sizePolicy)
+        control.setSizePolicy(sizePolicy)
     if addToLayout and parent and parent.layout() is not None:
         _addSpace(parent, addSpaceBefore)
         parent.layout().addWidget(box or control, stretch)

--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -1772,6 +1772,7 @@ def auto_commit(widget, master, value, label, auto_label=None, box=False,
 
     b.button = btn = VariableTextPushButton(
         b, text=label, textChoiceList=[label, auto_label], clicked=do_commit)
+    btn.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)
     if b.layout() is not None:
         if is_macstyle():
             btnpaddingbox = vBox(b, margin=0, spacing=0)
@@ -1781,7 +1782,7 @@ def auto_commit(widget, master, value, label, auto_label=None, box=False,
             b.layout().addWidget(btn)
 
     if not checkbox_label:
-        btn.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        btn.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
     checkbox_toggled()
     setattr(master, commit_name, unconditional_commit)
     misc['addToLayout'] = addToLayout

--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -1727,7 +1727,6 @@ def auto_commit(widget, master, value, label, auto_label=None, box=True,
             orientation = Qt.Vertical if checkbox_label else Qt.Horizontal
         b = widgetBox(widget, box=box, orientation=orientation,
                       addToLayout=False)
-        b.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)
 
     b.checkbox = cb = checkBox(b, master, value, checkbox_label,
                                callback=checkbox_toggled, tooltip=auto_label)

--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -1639,7 +1639,7 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
     return combo
 
 
-def auto_commit(widget, master, value, label, auto_label=None, box=True,
+def auto_commit(widget, master, value, label, auto_label=None, box=False,
                 checkbox_label=None, orientation=None, commit=None,
                 callback=None, **misc):
     """
@@ -1727,10 +1727,12 @@ def auto_commit(widget, master, value, label, auto_label=None, box=True,
         b = widgetBox(widget, box=box, orientation=orientation,
                       addToLayout=False)
 
+    if _is_horizontal(orientation):
+        b.layout().addSpacing(4)
     b.checkbox = cb = checkBox(b, master, value, checkbox_label,
                                callback=checkbox_toggled, tooltip=auto_label)
     if _is_horizontal(orientation):
-        b.layout().addSpacing(10)
+        b.layout().addSpacing(4)
     cb.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
 
     b.button = btn = VariableTextPushButton(

--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -1749,18 +1749,25 @@ def auto_commit(widget, master, value, label, auto_label=None, box=False,
             auto_label = label.title() + " Automatically"
     if isinstance(box, QWidget):
         b = box
+        addToLayout = False
     else:
         if orientation is None:
             orientation = Qt.Vertical if checkbox_label else Qt.Horizontal
         b = widgetBox(widget, box=box, orientation=orientation,
-                      addToLayout=False)
+                      addToLayout=False, margin=0, spacing=0)
+        addToLayout = misc.get('addToLayout', True)
+        if addToLayout and widget and \
+                not widget.layout().isEmpty() \
+                and _is_horizontal(orientation) \
+                and isinstance(widget.layout(), QtWidgets.QHBoxLayout):
+            # put a separator before the checkbox
+            separator(b, 16, 0)
 
-    if _is_horizontal(orientation):
-        b.layout().addSpacing(4)
     b.checkbox = cb = checkBox(b, master, value, checkbox_label,
                                callback=checkbox_toggled, tooltip=auto_label)
     if _is_horizontal(orientation):
-        b.layout().addSpacing(4)
+        w = b.style().pixelMetric(QStyle.PM_CheckBoxLabelSpacing)
+        separator(b, w, 0)
     cb.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
 
     b.button = btn = VariableTextPushButton(
@@ -1777,8 +1784,7 @@ def auto_commit(widget, master, value, label, auto_label=None, box=False,
         btn.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
     checkbox_toggled()
     setattr(master, commit_name, unconditional_commit)
-    misc['addToLayout'] = misc.get('addToLayout', True) and \
-                          not isinstance(box, QtWidgets.QWidget)
+    misc['addToLayout'] = addToLayout
     miscellanea(b, widget, widget, **misc)
 
     cb.setAttribute(Qt.WA_LayoutUsesWidgetRect)

--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -2620,9 +2620,11 @@ def tabWidget(widget):
     return w
 
 
-def createTabPage(tab_widget, name, widgetToAdd=None, canScroll=False):
+def createTabPage(tab_widget, name, widgetToAdd=None, canScroll=False,
+                  orientation=Qt.Vertical):
     if widgetToAdd is None:
-        widgetToAdd = vBox(tab_widget, addToLayout=0, margin=4)
+        widgetToAdd = widgetBox(tab_widget, orientation=orientation,
+                                addToLayout=0, margin=4)
     if canScroll:
         scrollArea = QtWidgets.QScrollArea()
         tab_widget.addTab(scrollArea, name)

--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -180,7 +180,7 @@ class OWComponent:
 
 
 def miscellanea(control, box, parent,
-                addToLayout=True, stretch=0, sizePolicy=None, addSpace=False,
+                addToLayout=True, stretch=0, sizePolicy=None, addSpace=None,
                 disabled=False, tooltip=None, disabledBy=None,
                 addSpaceBefore=False, **kwargs):
     """
@@ -231,7 +231,7 @@ def miscellanea(control, box, parent,
     :param sizePolicy: the size policy for the box or the control
     :type sizePolicy: QSizePolicy
     """
-    if addSpace is not False:
+    if addSpace is not None:
         warnings.warn("'addSpace' has been deprecated. Use gui.separator instead.",
                       DeprecationWarning, stacklevel=3)
     for prop, val in kwargs.items():
@@ -1199,7 +1199,7 @@ radioButtonsInBox = radioButtons
 
 def appendRadioButton(group, label, insertInto=None,
                       disabled=False, tooltip=None, sizePolicy=None,
-                      addToLayout=True, stretch=0, addSpace=False, id=None):
+                      addToLayout=True, stretch=0, addSpace=None, id=None):
     """
     Construct a radio button and add it to the group. The group must be
     constructed with :obj:`radioButtons` since it adds additional
@@ -1218,6 +1218,9 @@ def appendRadioButton(group, label, insertInto=None,
     :type insertInto: QWidget
     :rtype: QRadioButton
     """
+    if addSpace is not None:
+        warnings.warn("'addSpace' has been deprecated. Use gui.separator instead.",
+                      DeprecationWarning, stacklevel=2)
     i = len(group.buttons)
     if isinstance(label, str):
         w = QtWidgets.QRadioButton(label)

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -486,7 +486,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                                       QSizePolicy.Preferred)
             self.controlArea = gui.vBox(scroll_area, spacing=0,
                                         sizePolicy=(QSizePolicy.MinimumExpanding,
-                                                    QSizePolicy.MinimumExpanding))
+                                                    QSizePolicy.Preferred))
             scroll_area.setWidget(self.controlArea)
 
             self.left_side.layout().addWidget(scroll_area)

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -512,6 +512,8 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         self.controlArea.layout().setContentsMargins(*m)
 
     def _insert_buttons_area(self):
+        if not self.want_main_area:
+            gui.separator(self.left_side)
         self.buttonsArea = gui.widgetBox(
             self.left_side, addSpace=0, spacing=6,
             orientation=self.buttons_area_orientation,

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -963,6 +963,31 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             # Note: This should always be stored as bytes and not QByteArray.
             self.savedWidgetGeometry = bytes(self.saveGeometry())
 
+    def sizeHint(self):
+        sh = QSize()
+        # boxes look nice on macOS with starting width/height 4
+        width = 4
+        height = 4
+
+        if self.want_message_bar:
+            msh = self.statusBar().sizeHint()
+            height += msh.height()
+        if self.want_control_area:
+            csh = self.controlArea.sizeHint()
+            width += csh.width()
+            height += csh.height()
+            if self.buttons_area_orientation:
+                bsh = self.buttonsArea.sizeHint()
+                height += bsh.height()
+        height = max(height, 500)
+        if self.want_main_area:
+            width += self.__splitter.handleWidth()
+            if self.want_control_area:
+                width += height * 1.1
+            else:
+                return super().sizeHint()
+        return QSize(width, height)
+
     # when widget is resized, save the new width and height
     def resizeEvent(self, event):
         """Overloaded to save the geometry (width and height) when the widget

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -485,7 +485,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             scroll_area.setSizePolicy(QSizePolicy.MinimumExpanding,
                                       QSizePolicy.Preferred)
             self.controlArea = gui.vBox(scroll_area, spacing=0,
-                                        sizePolicy=(QSizePolicy.Fixed,
+                                        sizePolicy=(QSizePolicy.MinimumExpanding,
                                                     QSizePolicy.MinimumExpanding))
             scroll_area.setWidget(self.controlArea)
 

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -246,6 +246,10 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     #: should it not already be part of a package.
     category: str = None
 
+    #: Ratio between width and height for mainArea widgets,
+    #: set to None for super().sizeHint()
+    mainArea_width_height_ratio: Optional[float] = 1.1
+
     # -------------------------------------------------------------------------
     # Private Interface
     # -------------------------------------------------------------------------
@@ -966,6 +970,11 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             self.savedWidgetGeometry = bytes(self.saveGeometry())
 
     def sizeHint(self):
+        if self.mainArea_width_height_ratio is None:
+            return super().sizeHint()
+
+        # Super sizeHint with scroll_area isn't calculated right (slightly too small on macOS)
+        # on some platforms. This way, width/height should be optimal for most widgets.
         sh = QSize()
         # boxes look nice on macOS with starting width/height 4
         width = 4
@@ -985,7 +994,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         if self.want_main_area:
             width += self.__splitter.handleWidth()
             if self.want_control_area:
-                width += height * 1.1
+                width += height * self.mainArea_width_height_ratio
             else:
                 return super().sizeHint()
         return QSize(width, height)

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -499,7 +499,9 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
         if self.buttons_area_orientation is not None:
             self._insert_buttons_area()
-            self.buttonsArea.layout().setContentsMargins(*m)
+            self.buttonsArea.layout().setContentsMargins(
+                m[0] + 8, m[1], m[2] + 8, m[3]
+            )
             # margins are nice on macOS with this
             m = m[0], m[1], m[2], m[3] - 2
 

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -476,7 +476,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         self.layout().addWidget(self.__splitter)
 
     def _insert_control_area(self):
-        self.left_side = gui.vBox(self.__splitter, addSpace=0)
+        self.left_side = gui.vBox(self.__splitter, addSpace=0, spacing=0)
         if self.want_main_area:
             self.left_side.setSizePolicy(
                 QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
@@ -484,7 +484,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             scroll_area = VerticalScrollArea(self.left_side)
             scroll_area.setSizePolicy(QSizePolicy.MinimumExpanding,
                                       QSizePolicy.Preferred)
-            self.controlArea = gui.vBox(scroll_area, spacing=0,
+            self.controlArea = gui.vBox(scroll_area, spacing=6,
                                         sizePolicy=(QSizePolicy.MinimumExpanding,
                                                     QSizePolicy.Preferred))
             scroll_area.setWidget(self.controlArea)
@@ -493,7 +493,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
             m = 4, 4, 0, 4
         else:
-            self.controlArea = gui.vBox(self.left_side, spacing=0)
+            self.controlArea = gui.vBox(self.left_side, spacing=6)
 
             m = 4, 4, 4, 4
 
@@ -507,7 +507,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
     def _insert_buttons_area(self):
         self.buttonsArea = gui.widgetBox(
-            self.left_side, addSpace=0, spacing=9,
+            self.left_side, addSpace=0, spacing=6,
             orientation=self.buttons_area_orientation,
             sizePolicy=(QSizePolicy.MinimumExpanding,
                         QSizePolicy.Maximum)
@@ -515,7 +515,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
     def _insert_main_area(self):
         self.mainArea = gui.vBox(
-            self.__splitter, margin=4,
+            self.__splitter, spacing=6,
             sizePolicy=QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         )
         self.__splitter.addWidget(self.mainArea)

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -553,7 +553,6 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         if not self.resizing_enabled:
             self.layout().setSizeConstraint(QVBoxLayout.SetFixedSize)
 
-        self.want_main_area = self.want_main_area or self.graph_name
         self._create_default_buttons()
 
         self._insert_splitter()

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -499,7 +499,9 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
         if self.buttons_area_orientation is not None:
             self._insert_buttons_area()
-            self.buttonsArea.layout().setContentsMargins(4, 4, 0, 4)
+            self.buttonsArea.layout().setContentsMargins(*m)
+            # margins are nice on macOS with this
+            m = m[0], m[1], m[2], m[3] - 2
 
         self.controlArea.layout().setContentsMargins(*m)
 


### PR DESCRIPTION
##### Issue
Widgets aren't visually consistent. It'll take a little bit of work in Orange3 and add-ons, but once we're there, everything will be nice. Most of the changes I made in the Orange3 PR simplify the code, I hope that's the case for addons too.

##### Description of changes
See commit history.

This was written on macOS 10.15.7, working with both QMacStyle and Plastic. Hoping Windows and Linux look ok.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
