### PR TITLE
Handle js_timeout in WebKitView based WebviewWidget

### DIFF
--- a/orangewidget/utils/webview.py
+++ b/orangewidget/utils/webview.py
@@ -436,6 +436,10 @@ if HAVE_WEBKIT:
 
     class WebviewWidget(_WebViewBase, WebKitView):
         def __init__(self, parent=None, bridge=None, *, debug=False, **kwargs):
+            # WebEngine base WebviewWidget has js_timeout parameter, since
+            # user do not know which one will get and passing js_timeout to
+            # WebKitView causes error we should remove
+            kwargs.pop("js_timeout", None)
             WebKitView.__init__(self, parent, bridge, debug=debug, **kwargs)
             _WebViewBase.__init__(self)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
WebKitView based WebViewWidget fails when getting `js_timout` while WebEngine based WebViewWidget accepts it. Since classes look the same for the user they should support the same parameters.

WebKitView based WebViewWidget

##### Description of changes
Remove the  `js_timeout` parameter before passing `kwargs` to `WebKitView`


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
