### PR TITLE
[RFC] Add automated summaries

### DIFF
--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -98,6 +98,7 @@ class WidgetMetaClass(type(QDialog)):
         if not cls.name: # not a widget
             return cls
         cls.convert_signals()
+        cls.set_default_auto_summary()
         cls.settingsHandler = \
             SettingsHandler.create(cls, template=cls.settingsHandler)
         return cls


### PR DESCRIPTION
## Issue

Ref: https://github.com/biolab/orange3/issues/5108

## Description of changes

###  Outputs

If:
- there is a signal marked with `auto_summary = True`
- or
    - no signal has `auto_summary = True`, and  
    - the widget has a single output or one of the outputs is marked as default,
    - and this signal's `auto_summary` is not explicitly set to `False`,
then calling `send` on this signal will also set the output summary.

The output summary is set if the output value is `None` or a summarising function for this data type is registered. An example of such function is

```python
@summarize.register(Table)
def summarize(data):
    return len(data), format_summary_details(data)
```

**Benefits**: simpler code, less room for error, easier unification and future changes. Also, all add-ons automatically receive this function.

**(Non-consequntial?) imcompatibility**: if a widget already implements setting an output summary (which most do) **and** the summary differs from what would be generated automatically (mostly not) **and** the summary is set before sending the signal (mostly not), **then** the explicit summary will be overridden. This should not be a big problem and can be disabled by turning the auto summary for the default signal off.

Another solution that we discussed (turning auto summary off at the first explicit call of `set_output_summary` is a bad idea because (a) it adds uncontrollable magic, (b) is not really needed, (c) output summaries will be refactored anyway if this is merged and, most importantly (d) `set_output_summary` does not hold a reference to the widget and/or the signal, so it doesn't know what to disable. And it should stay that way.

## Inputs

Inputs follow the same logic for designating the signal for the summary and use the same functions for summarizing. The implementation works by using the existing `@Input` decorator to intercept the incoming signal and set the summary.


##### Includes
- [X] Code changes
- [ ] Tests
- [x] Documentation
