### PR TITLE
Add automated summaries

### DIFF
--- a/orangewidget/utils/signals.py
+++ b/orangewidget/utils/signals.py
@@ -407,13 +407,7 @@ class WidgetSignalsMixin:
             if not partials:
                 return "-", "-"
             shorts = " ".join(map(format_short, partials.values()))
-            if len(partials) == 1:
-                details = format_detail(next(iter(partials.values())))
-            else:
-                details = "<ul>" \
-                          + "".join(f"<li>{format_detail(partial)}</li>"
-                                    for partial in partials.values()) \
-                          + "</ul>"
+            details = "<br/>".join(format_detail(partial) for partial in partials.values())
             return shorts, details
 
         if not any(summaries.values()):

--- a/orangewidget/utils/signals.py
+++ b/orangewidget/utils/signals.py
@@ -33,13 +33,13 @@ summarize = singledispatch(base_summarize)
 SUMMARY_STYLE = """
 <style>
     ul {
-        margin-left: 10px;
+        margin-left: 4px;
         margin-top: 2px;
-        -qt-list-indent:0
+        -qt-list-indent:1
     }
 
     li {
-        margin-top: 3px;
+        margin-bottom: 3px;
     }
 
     th {
@@ -407,7 +407,7 @@ class WidgetSignalsMixin:
             if not partials:
                 return "-", "-"
             shorts = " ".join(map(format_short, partials.values()))
-            details = "<br/>".join(format_detail(partial) for partial in partials.values())
+            details = "".join(format_detail(partial) for partial in partials.values())
             return shorts, details
 
         if not any(summaries.values()):

--- a/orangewidget/utils/signals.py
+++ b/orangewidget/utils/signals.py
@@ -406,7 +406,7 @@ class WidgetSignalsMixin:
         def join_multiples(partials):
             if not partials:
                 return "-", "-"
-            shorts = ",".join(map(format_short, partials.values()))
+            shorts = " ".join(map(format_short, partials.values()))
             if len(partials) == 1:
                 details = format_detail(next(iter(partials.values())))
             else:

--- a/orangewidget/utils/signals.py
+++ b/orangewidget/utils/signals.py
@@ -407,7 +407,7 @@ class WidgetSignalsMixin:
             if not partials:
                 return "-", "-"
             shorts = " ".join(map(format_short, partials.values()))
-            details = "".join(format_detail(partial) for partial in partials.values())
+            details = "<br/>".join(format_detail(partial) for partial in partials.values())
             return shorts, details
 
         if not any(summaries.values()):

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -343,6 +343,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         self.__splitter = None
         if self.want_basic_layout:
             self.set_basic_layout()
+            self.update_summaries()
 
         sc = QShortcut(QKeySequence(Qt.ShiftModifier | Qt.Key_F1), self)
         sc.activated.connect(self.__quicktip)


### PR DESCRIPTION
#### Issue

Provide automated summaries for inputs and outputs. Ref: https://github.com/biolab/orange3/issues/5108.

For proper effect, must be merged with https://github.com/biolab/orange3/pull/5308, but nothing should break if not.

Also: resolves #109.

#### Description of changes

- Outputs are intercepted on calls to `send` (only new-style signals are supported; this is intentionally as the "old-style" are deprecated for many many years)
- Inputs are intercepted by using the existing decorator that marks inputs

Auto-summary is generated if
- the signal's `auto_summary` flag is not explicitly set to `False`,
- the signal type has a registered summarizing function.

Summarizing functions are registered by adding another type to single-dispatched `orangewidget.utils.signals.summarize`, which must return an instance of `orangewidget.utils.signals.PartialSummary`, e.g.

```python
@summarize.register(Table)
def summarize(data):
    return PartialSummary(data.approx_len(), format_summary_details(data))
```

The summary (first argument), can be `None`, `int` or rich text `str` (it has to be html-safe!), and the second is `None` (if also the first is `None`) or a rich text `str`.

**(Non-consequential?) imcompatibility**: if a widget already implement sets the output summary, the one who acts last will override the one who's first. That is, either nothing will change or the summary will (probably) improve.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
