### PR TITLE
gui: Make draggable spinbox text selectable, fix disabled behavior

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -594,7 +594,8 @@ class SpinBoxMixin:
             self.cfunc()
 
     def eventFilter(self, obj, event):
-        if not (isinstance(obj, SpinBoxMixin) or isinstance(obj, QLineEdit)):
+        if not self.isEnabled() or \
+                not (isinstance(obj, SpinBoxMixin) or isinstance(obj, QLineEdit)):
             return super().eventFilter(obj, event)
 
         cursor = Qt.SizeVerCursor if self.verticalDirection else Qt.SizeHorCursor

--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -617,11 +617,12 @@ class SpinBoxMixin:
 
             pos = event.globalPos()
             posVal = pos.y() if self.verticalDirection else -pos.x()
-            valueOffset = (self.mouseStartPos - posVal) * self.stepSize
+            diff = self.mouseStartPos - posVal
+            # these magic params are pretty arbitrary, ensure that it's still
+            # possible to easily highlight the text if moving mouse slightly
+            # up/down, with the default stepsize
+            valueOffset = int((diff / 25) ** 3) * self.stepSize
             self.setValue(self.preDragValue + valueOffset)
-
-            event.accept()
-            return True
         elif event.type() == QEvent.MouseButtonRelease:
             # end click+drag
             # restore default cursor on release


### PR DESCRIPTION
##### Issue
Fixes #134 

##### Description of changes
It still listens for drag events on the text, but I've made the value increase exponentially (not linearly), so it should be easy enough to select the text. Is this okay? If not, I'll remove the listener from the textbox. @borondics @janezd 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
