### PR TITLE
Provider.initialize: unpack settings instead of just copying

### DIFF
--- a/orangewidget/settings.py
+++ b/orangewidget/settings.py
@@ -304,7 +304,10 @@ class SettingProvider:
                 value.name = name
                 self.providers[name] = value
 
-    def initialize(self, component: OWComponent, data: Optional[dict] = None) \
+    def initialize(self,
+                   component: OWComponent,
+                   data: Optional[dict] = None,
+                   handler: Optional["SettingsHandler"] = None) \
             -> None:
         """
         Initialize instance settings to given data or to defaults.
@@ -315,14 +318,24 @@ class SettingProvider:
         Args:
             component (OWComponent): widget or component to initialize
             data (dict or None): data used to override the defaults
+            handler (SettingsHandler): settings handler; may be omitted if
+                component is a widget or if there is neither data nor
+                self.initialization_data.
         """
+        if handler is None and hasattr(component, "settingsHandler"):
+            handler = component.settingsHandler
+
         if data is None:
             data = self.initialization_data
 
         for name, setting in self.settings.items():
-            value = data.get(name, setting.default)
-            if not isinstance(value, _IMMUTABLES):
-                value = copy.copy(value)
+            if data is not None and name in data:
+                assert handler is not None
+                value = handler.unpack_value(data[name], setting.type)
+            else:
+                value = setting.default
+                if not isinstance(value, _IMMUTABLES):
+                    value = copy.copy(value)
             setattr(component, name, value)
 
         for name, provider in self.providers.items():
@@ -333,7 +346,7 @@ class SettingProvider:
             if member is None or isinstance(member, SettingProvider):
                 provider.store_initialization_data(data[name])
             else:
-                provider.initialize(member, data[name])
+                provider.initialize(member, data[name], handler)
 
     def reset_to_original(self, instance):
         self.initialize(instance)
@@ -654,7 +667,7 @@ class SettingsHandler:
         if provider is self.provider:
             data = self._add_defaults(data)
 
-        provider.initialize(component, data)
+        provider.initialize(component, data, self)
 
     def reset_to_original(self, widget: "OWBaseWidget") -> None:
         provider = self._select_provider(widget)

--- a/orangewidget/tests/test_settings_handler.py
+++ b/orangewidget/tests/test_settings_handler.py
@@ -133,20 +133,20 @@ class SettingHandlerTestCase(WidgetTest):
 
         # No data
         handler.initialize(widget)
-        provider.initialize.assert_called_once_with(widget, {'default': 42,
-                                                             'setting': 1})
+        provider.initialize.assert_called_once_with(
+            widget, {'default': 42, 'setting': 1}, handler)
 
         # Dictionary data
         reset_provider()
         handler.initialize(widget, {'setting': 5})
-        provider.initialize.assert_called_once_with(widget, {'default': 42,
-                                                             'setting': 5})
+        provider.initialize.assert_called_once_with(
+            widget, {'default': 42, 'setting': 5}, handler)
 
         # Pickled data
         reset_provider()
         handler.initialize(widget, pickle.dumps({'setting': 5}))
-        provider.initialize.assert_called_once_with(widget, {'default': 42,
-                                                             'setting': 5})
+        provider.initialize.assert_called_once_with(
+            widget, {'default': 42, 'setting': 5}, handler)
 
     def test_initialize_component(self):
         handler = SettingsHandler()
@@ -159,17 +159,19 @@ class SettingHandlerTestCase(WidgetTest):
 
         # No data
         handler.initialize(widget)
-        provider.initialize.assert_called_once_with(widget, None)
+        provider.initialize.assert_called_once_with(widget, None, handler)
 
         # Dictionary data
         provider.reset_mock()
         handler.initialize(widget, {'setting': 5})
-        provider.initialize.assert_called_once_with(widget, {'setting': 5})
+        provider.initialize.assert_called_once_with(
+            widget, {'setting': 5}, handler)
 
         # Pickled data
         provider.reset_mock()
         handler.initialize(widget, pickle.dumps({'setting': 5}))
-        provider.initialize.assert_called_once_with(widget, {'setting': 5})
+        provider.initialize.assert_called_once_with(
+            widget, {'setting': 5}, handler)
 
     def test_schema_only_settings(self):
         handler = SettingsHandler()


### PR DESCRIPTION
##### Issue

Should fix https://github.com/biolab/orange3/issues/5339.

##### Description of changes

`Provider.initialize` did not unpack stored settings.

##### Includes
- [X] Code changes