### PR TITLE
[FIX] widget: Avoid sizeHint if want_basic_layout is False

### DIFF
--- a/orangewidget/tests/test_widget.py
+++ b/orangewidget/tests/test_widget.py
@@ -94,6 +94,7 @@ class WidgetTestCase(WidgetTest):
         w = TestWidget2()
         w.showEvent(QShowEvent())
         QTest.mousePress(w, Qt.LeftButton, Qt.NoModifier, QPoint(1, 1))
+        _ = w.sizeHint()
 
     def test_store_restore_layout_geom(self):
         class Widget(OWBaseWidget):

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -973,7 +973,8 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             self.savedWidgetGeometry = bytes(self.saveGeometry())
 
     def sizeHint(self):
-        if self.mainArea_width_height_ratio is None:
+        if not self.want_basic_layout \
+                or self.mainArea_width_height_ratio is None:
             return super().sizeHint()
 
         # Super sizeHint with scroll_area isn't calculated right (slightly too small on macOS)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

If want_basic_layout = False then `sizeHint` raises an exception
```
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange-widget-base/orangewidget/widget.py", line 990, in sizeHint
    csh = self.controlArea.sizeHint()
AttributeError: 'NoneType' object has no attribute 'sizeHint'
```

##### Description of changes

* Avoid sizeHint overload if want_basic_layout is False

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
