### PR TITLE
_apply_setting: trigger control update

### DIFF
--- a/orangewidget/settings.py
+++ b/orangewidget/settings.py
@@ -187,16 +187,20 @@ def _apply_setting(setting: Setting, instance: OWComponent, value: Any):
     If old and new values are of the same type, and the type is either a list
     or has methods `clear` and `update`, setting is updated in place. Otherwise
     the function calls `setattr`.
+
+    Even if the target is update this way, call setattr (effectively calling
+    instance.target = instance.target) to trigger any automatic updates related
+    to this attribute).
     """
     target = getattr(instance, setting.name, None)
     if type(target) is type(value):
         if isinstance(value, list):
             target[:] = value
-            return
+            value = target
         elif hasattr(value, "clear") and hasattr(value, "update"):
             target.clear()
             target.update(value)
-            return
+            value = target
     setattr(instance, setting.name, value)
 
 


### PR DESCRIPTION
##### Issue

At some point, we (probably: I) decided that `_apply_setting`, which copies a setting to a widget should update mutable settings instead of assigning new values. This decision was correct because it keeps any references to these objects valid.

Updates of UX controls are triggered by assigning values to widget's attributes; e.g. if `self.allow_metas` is tied to some checkbox, setting `self.allow_metas = True` will update the state of that checkbox.

A problem with the above decision is thus that updating in place does not trigger an update of the UX control. This is a problem particularly in selections in list views, which store the selection in a list of variables. When opening the context, the selection is properly updated but not reflected in the list view.

Until now, the few widgets that use listviews of attributes with selections stored as setting have solved this by re-assigning the value, e.g., `self.selection = self.selection`. Unless we forgot.

##### Description of changes

This PR resolves in general this by 're-assigning' within `_apply_setting`.

For any widget that currently already does it by itself, this shouldn't cause any problems - the value of the UX will be set twice.

##### Includes
- [X] Code changes
