### PR TITLE
Don't call auto summary on derived inputs

### DIFF
--- a/orangewidget/tests/test_widget.py
+++ b/orangewidget/tests/test_widget.py
@@ -36,6 +36,14 @@ class MyWidget(OWBaseWidget):
         self.widget = None
 
 
+class SignalTypeA:
+    pass
+
+
+class SignalTypeB:
+    pass
+
+
 class WidgetTestCase(WidgetTest):
     def test_setattr(self):
         widget = self.create_widget(MyWidget)
@@ -484,13 +492,26 @@ class WidgetTestInfoSummary(WidgetTest):
         self.assertEqual(StateInfo.format_number(999_999), "1M")
         self.assertEqual(StateInfo.format_number(1_000_000), "1M")
 
+    def test_overriden_handler(self):
+        class TestWidget(OWBaseWidget, openclass=True):
+            class Inputs(OWBaseWidget.Inputs):
+                inputA = Input("a", SignalTypeA)
 
-class SignalTypeA:
-    pass
+            @Inputs.inputA
+            def handler(self, _):
+                pass
 
+        class DerivedWidget(TestWidget):
+            name = "tw"
 
-class SignalTypeB:
-    pass
+            @TestWidget.Inputs.inputA
+            def handler(self, obj):
+                super().handler(obj)
+
+        widget = self.create_widget(DerivedWidget)
+        widget.set_partial_input_summary = MagicMock()
+        self.send_signal(widget.Inputs.inputA, SignalTypeA())
+        widget.set_partial_input_summary.assert_called_once()
 
 
 @summarize.register(SignalTypeA)

--- a/orangewidget/utils/signals.py
+++ b/orangewidget/utils/signals.py
@@ -188,13 +188,16 @@ class Input(InputSignal, _Signal):
         """
         if self.flags & Multiple:
             def summarize_wrapper(widget, value, id=None):
-                widget.set_partial_input_summary(
-                    self.name, summarize(value), id=id)
+                # If this method is overridden, don't summarize
+                if summarize_wrapper is getattr(type(widget), method.__name__):
+                    widget.set_partial_input_summary(
+                        self.name, summarize(value), id=id)
                 method(widget, value, id)
         else:
             def summarize_wrapper(widget, value):
-                widget.set_partial_input_summary(
-                    self.name, summarize(value))
+                if summarize_wrapper is getattr(type(widget), method.__name__):
+                    widget.set_partial_input_summary(
+                        self.name, summarize(value))
                 method(widget, value)
 
         # Re-binding with the same name can happen in derived classes
@@ -266,9 +269,11 @@ class MultiInput(Input):
 
     def __call__(self, method):
         def summarize_wrapper(widget, index, value):
-            ids = self.__get_summary_ids(widget)
-            widget.set_partial_input_summary(
-                self.name, summarize(value), id=ids[index], index=index)
+            # If this method is overridden, don't summarize
+            if summarize_wrapper is getattr(type(widget), method.__name__):
+                ids = self.__get_summary_ids(widget)
+                widget.set_partial_input_summary(
+                    self.name, summarize(value), id=ids[index], index=index)
             method(widget, index, value)
         _ = super().__call__(method)
         return summarize_wrapper if self.auto_summary else method
@@ -278,8 +283,9 @@ class MultiInput(Input):
         def summarize_wrapper(widget, index, value):
             ids = self.__get_summary_ids(widget)
             ids.insert(index, next(self.__id_gen))
-            widget.set_partial_input_summary(
-                self.name, summarize(value), id=ids[index], index=index)
+            if summarize_wrapper is getattr(type(widget), method.__name__):
+                widget.set_partial_input_summary(
+                    self.name, summarize(value), id=ids[index], index=index)
             method(widget, index, value)
         self.insert_handler = method.__name__
         return summarize_wrapper if self.auto_summary else method
@@ -289,8 +295,9 @@ class MultiInput(Input):
         def summarize_wrapper(widget, index):
             ids = self.__get_summary_ids(widget)
             id_ = ids.pop(index)
-            widget.set_partial_input_summary(
-                self.name, summarize(None), id=id_)
+            if summarize_wrapper is getattr(type(widget), method.__name__):
+                widget.set_partial_input_summary(
+                    self.name, summarize(None), id=id_)
             method(widget, index)
         self.remove_handler = method.__name__
         return summarize_wrapper if self.auto_summary else method

--- a/orangewidget/utils/signals.py
+++ b/orangewidget/utils/signals.py
@@ -77,7 +77,7 @@ def can_summarize(type_, name, explicit):
         if summarize.dispatch(a_type) is base_summarize:
             warnings.warn(
                 f"register 'summarize' function for type {a_type.__name__}. "
-                + instr, UserWarning)
+                + instr, UserWarning, stacklevel=4)
             return False
     return True
 
@@ -281,9 +281,9 @@ class MultiInput(Input):
     def insert(self, method):
         """Register the method as the insert handler"""
         def summarize_wrapper(widget, index, value):
-            ids = self.__get_summary_ids(widget)
-            ids.insert(index, next(self.__id_gen))
             if summarize_wrapper is getattr(type(widget), method.__name__):
+                ids = self.__get_summary_ids(widget)
+                ids.insert(index, next(self.__id_gen))
                 widget.set_partial_input_summary(
                     self.name, summarize(value), id=ids[index], index=index)
             method(widget, index, value)
@@ -293,9 +293,9 @@ class MultiInput(Input):
     def remove(self, method):
         """"Register the method as the remove handler"""
         def summarize_wrapper(widget, index):
-            ids = self.__get_summary_ids(widget)
-            id_ = ids.pop(index)
             if summarize_wrapper is getattr(type(widget), method.__name__):
+                ids = self.__get_summary_ids(widget)
+                id_ = ids.pop(index)
                 widget.set_partial_input_summary(
                     self.name, summarize(None), id=id_)
             method(widget, index)


### PR DESCRIPTION
##### Issue

If an input signal handler is overridden in derived class, auto summary is called in each handler.

##### Description of changes

Before calling the summary, check that the method is not overridden.

##### Includes
- [X] Code changes
- [X] Tests