### PR TITLE
[FIX] read_defaults: ignore schema-only settings

### DIFF
--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -742,7 +742,7 @@ def open_widget_classes():
 
 
 @contextmanager
-def override_default_settings(widget, defaults=None, handler=None):
+def override_default_settings(widget, defaults=None, context_defaults=[], handler=None):
     if defaults is None:
         defaults = {}
 
@@ -754,6 +754,7 @@ def override_default_settings(widget, defaults=None, handler=None):
     os.makedirs(os.path.dirname(filename), exist_ok=True)
     with open(filename, "wb") as f:
         pickle.dump(defaults, f)
+        pickle.dump(context_defaults, f)
 
     yield
 


### PR DESCRIPTION
##### Issue

The widget defaults should contain no schema-only settings. When defaults are written, schema-only settings are removed.

But saved defaults could still contain schema-only settings in some cases, such as (1) migration creates a schema-only setting (as we sometimes do for backward compatibility), or (2) we change a setting to schema-only.

This bug was found by @stuart-cls when testing Quasars/orange-spectroscopy#561. We also have a similar bug in Orange master; it was introduced In biolab/orange3#4810.

##### Description of changes
This PR removes schema-only settings when defaults are initialized, which corrects a rare bug where schema-only settings are set to a non-default value for new widgets.

Now `.provider` needs to be set on a `SettingHandler` to open defaults; it is needed to identify schema-only settings. Is this a problem? I hope not - I needed to modify some tests in widget-base, but the other stuff seems to work.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
