### PR TITLE
QWebEngineView: increase send_object timeout

### DIFF
--- a/orangewidget/utils/webview.py
+++ b/orangewidget/utils/webview.py
@@ -533,7 +533,7 @@ elif HAVE_WEBENGINE:
             id = next(self._id_gen)
             value = self._objects[id] = dict(id=id, name=name, obj=obj)
             # Wait till JS is connected to receive objects
-            wait(until=lambda: self.receivers(self.objectChanged))
+            wait(until=lambda: self.receivers(self.objectChanged), timeout=30000)
             self.objectChanged.emit(value)
 
         @pyqtSlot(int)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
On slow machines (sometimes on any computer) connection to receive objects can take longer than default timeout 5s. 
Reproduce: Open any widget which uses highchart (line chart in timeseries).

##### Description of changes
Increasing timeout for connection to receive objects

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
