### PR TITLE
[FIX] ListViewSearch: handle filtering of newly inserted value

### DIFF
--- a/orangewidget/utils/tests/test_listview.py
+++ b/orangewidget/utils/tests/test_listview.py
@@ -55,6 +55,28 @@ class TestListViewSearch(GuiTest):
             [self.lv.isRowHidden(i) for i in range(num_items)],
         )
 
+    def test_insert_new_value(self):
+        num_items = 4
+        filter_row = self.lv.findChild(QLineEdit)
+        filter_row.grab()
+        self.lv.grab()
+
+        QTest.keyClick(filter_row, Qt.Key_E, delay=-1)
+        self.assertListEqual(
+            [False, True, False, True],
+            [self.lv.isRowHidden(i) for i in range(num_items)],
+        )
+
+        model = self.lv.model()
+        if model.insertRow(model.rowCount()):
+            index = model.index(model.rowCount() - 1, 0)
+            model.setData(index, "six")
+
+        self.assertListEqual(
+            [False, True, False, True, True],
+            [self.lv.isRowHidden(i) for i in range(num_items + 1)],
+        )
+
     def test_empty(self):
         self.lv.setModel(QStringListModel([]))
         self.assertEqual(0, self.lv.model().rowCount())


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When using VariableListModel (which updates model with inserting, removing and do not change the root) filtering is not applied on new values. 

Reason:
`__filter_rowsAboutToBeRemoved` is not called for newly inserted rows that are filtered out due to the current filter string. This function is not called since the proxy model skip them directly (without inserting). Insertion happens anyway by model assigned to the list view.

Reproduce:
1. Use the file widget in Orange and select Iris
2. Connect discretize widget and filter values in list view
3. Change the dataset to housing in the file widget
4. Observe that filtering is not applied to new values in the list

##### Description of changes
Filter values that are inserted by the model are set to the list view.
@ales-erjavec if you have any better solution you are welcome to suggest it or to correct the pull request.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
