### PR TITLE
[CI] gh-actions: Replace ubuntu-16.04 worker

### DIFF
--- a/.github/workflows/run-docs-build.yml
+++ b/.github/workflows/run-docs-build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: False
       matrix:
         include:
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             python: 3.6
 
     steps:

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           # Linux
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             python-version: 3.6
             test-env: "PyQt5~=5.9.2"
 

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           # Linux
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             python-version: 3.6
             test-env: "PyQt5~=5.9.2"
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->


ubuntu-16.04 GH Actions worker was deprecated and removed - https://github.com/actions/virtual-environments/issues/3287

##### Description of changes

Replace ubuntu-16.04 worker

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
