### PR TITLE
[FIX] signals: Fix MultiInput index tracking for `filter_none`

### DIFF
--- a/orangewidget/utils/signals.py
+++ b/orangewidget/utils/signals.py
@@ -657,7 +657,7 @@ def set_multi_input_helper(
     inout.closing_sentinel as the obj.
     """
     inputs_ = get_widget_inputs(widget)
-    inputs = list(inputs_.setdefault(input.name, ()))
+    inputs = inputs_.setdefault(input.name, ())
     filter_none = input.filter_none
 
     signal_old = None
@@ -672,15 +672,16 @@ def set_multi_input_helper(
         index = key_to_pos.get(key)
         assert index is not None
 
+    inputs_updated = list(inputs)
     if new:
-        inputs.insert(index, (key, obj))
+        inputs_updated.insert(index, (key, obj))
     elif remove:
-        signal_old = inputs.pop(index)
+        signal_old = inputs_updated.pop(index)
     else:
-        signal_old = inputs[index]
-        inputs[index] = (key, obj)
+        signal_old = inputs_updated[index]
+        inputs_updated[index] = (key, obj)
 
-    inputs_[input.name] = tuple(inputs)
+    inputs_[input.name] = tuple(inputs_updated)
 
     if filter_none:
         def filter_f(obj):
@@ -716,6 +717,8 @@ def set_multi_input_helper(
             if filter_f(signal_old[1]):
                 # was already notified as removed, only remove from inputs (done above)
                 return
+            else:
+                index = local_index(key, inputs, filter_f)
         elif update and filtered:
             if filter_f(signal_old[1]):
                 # did not change; remains filtered

--- a/orangewidget/utils/signals.py
+++ b/orangewidget/utils/signals.py
@@ -708,9 +708,13 @@ def set_multi_input_helper(
         if new and filtered:
             # insert in inputs only (done above)
             return
+        elif new:
+            # Some inputs before this might be filtered invalidating the
+            # effective index. Find appropriate index for insertion
+            index = len([obj for _, obj in inputs[:index] if not filter_f(obj)])
         elif remove:
             if filter_f(signal_old[1]):
-                # was already removed, only remove from inputs (done above)
+                # was already notified as removed, only remove from inputs (done above)
                 return
         elif update and filtered:
             if filter_f(signal_old[1]):
@@ -722,6 +726,8 @@ def set_multi_input_helper(
                 new = False
                 index = local_index(key, inputs, filter_f)
                 assert index is not None
+        elif update:
+            index = local_index(key, inputs, filter_f)
 
         if signal_old is not None and filter_f(signal_old[1]) and not filtered:
             # update with non-none value, substitute as new signal

--- a/orangewidget/workflow/tests/test_widgetsscheme.py
+++ b/orangewidget/workflow/tests/test_widgetsscheme.py
@@ -528,6 +528,25 @@ class TestSignalManager(GuiTest):
         check_inputs([2])
         model.remove_link(l1)
         check_inputs([2])
+        reset_events()
+
+        model.remove_link(l2)
+        check_inputs([])
+        check_events([("remove", 0)])
+        reset_events()
+
+        w1.Outputs.out.send(None)
+        w2.Outputs.out.send(1)
+        model.insert_link(0, l1)
+        model.insert_link(1, l2)
+        check_inputs([1])
+        check_events([("insert", 0, 1)])
+        reset_events()
+        # ensure proper index on input removal when preceding inputs are
+        # filtered
+        model.remove_link(l2)
+        check_inputs([])
+        check_events([("remove", 0)])
 
     def test_old_style_input(self):
         model, widgets = create_workflow()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes https://github.com/biolab/orange3/issues/5611

##### Description of changes

Fix effective input index tracking for MultiInput Input when `filter_none=True`

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
