### PR TITLE
OWComponent: replace hasattr with getattr_static for controlled_attributes

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -7,6 +7,7 @@ import re
 import itertools
 import warnings
 import logging
+from inspect import getattr_static
 from types import LambdaType
 from collections import defaultdict
 
@@ -184,7 +185,7 @@ class OWComponent:
         else:
             super().__setattr__(name, value)
             # First check that the widget is not just being constructed
-            if hasattr(self, "controlled_attributes"):
+            if getattr_static(self, "controlled_attributes", None) is not None:
                 self._on_attr_changed(name, value)
 
     def _on_attr_changed(self, name, value):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
It is not really an issue but a way to avoid further problems with other class implementations. In  `OWComponent` `hasattr` is used to check if controlled_attributes is already initialised. Besides checking to object's dict it will also call `__getattr__`. In case that the other object (that object inheriting OWComponent mixin is inheriting too) is not fully initialized and they overlooked the possibility of call of __getattr__ on noninitialized object `hasattr` will fail. 

##### Description of changes
I discovered this issue on pyqtgraph's `PlotWidget`. I will propose the change there too but it would take time before they propose a new release. So I think I can speed up the process if I do propose the following change here.  It, in my opinion, will not do a harm since we actually want to check if `controlled_attributes` is defined by init of `OWComponent`. It will also prevent similar issues in the future.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
