### PR TITLE
Test function commit_and_wait: fix for undecorated commits

### DIFF
--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -498,7 +498,11 @@ class WidgetTest(GuiTest):
         if widget is None:
             widget = self.widget
 
-        widget.commit.now()
+        if hasattr(widget.commit, "now"):
+            widget.commit.now()
+        else:
+            # Support for deprecated, non-decorated commit
+            widget.unconditional_commit()
         self.wait_until_finished(widget=widget, timeout=wait)
 
     def get_output(self, output, widget=None, wait=DEFAULT_TIMEOUT):


### PR DESCRIPTION
##### Issue

Utility function for tests `commit_and_wait` does not work for undecorated commit methods.

##### Description of changes

Check whether the method is decorated and use the corresponding method.

##### Includes
- [X] Code changes
