### PR TITLE
[FIX] widget: Restore controlAreaVisibility when save_position is False

### DIFF
--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -1058,11 +1058,11 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         """Overloaded to restore the geometry when the widget is shown
         """
         QDialog.showEvent(self, event)
-        if self.save_position and not self.__was_restored:
-            # Restore saved geometry on (first) show
+        if not self.__was_restored:
+            # Restore saved geometry/layout on (first) show
             if self.__splitter is not None:
                 self.__setControlAreaVisible(self.controlAreaVisible)
-            if self.savedWidgetGeometry is not None:
+            if self.save_position and self.savedWidgetGeometry is not None:
                 self.__restoreWidgetGeometry(bytes(self.savedWidgetGeometry))
             self.__was_restored = True
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes: gh-170

##### Description of changes

 Restore controlAreaVisibility when save_position is False

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
