### PR TITLE
Fix read-the-docs builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,9 @@
 version: 2
 
 python:
-   version: 3.6
+   version: 3.8
    install:
       - requirements: doc/requirements-rtd.txt
-      - method: pip
-        path: .
+        # no - method: pip here, -e . is already in doc/requirements-rtd.txt
 
    system_packages: true

--- a/doc/requirements-rtd.txt
+++ b/doc/requirements-rtd.txt
@@ -1,7 +1,11 @@
 --only-binary PyQt5,matplotlib
 
 setuptools
-sphinx~=3.2.1
+sphinx>=4.2.0
 AnyQt
 PyQt5~=5.12.1
 PyQtWebengine~=5.12.1
+# sphinx pins docutils version, but the installation in the RTD worker/config
+# overrides it because docutils is also in our transitive dependencies.
+# https://docs.readthedocs.io/en/stable/faq.html#i-need-to-install-a-package-in-a-environment-with-pinned-versions
+-e .


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Documentation faild fails sicne docutils 0.18 is not compatible with shphinx

##### Description of changes
The problem is solved in the newest sphinx (they pin docutils). -> pinning sphinx to newest versions

After pinning the other error appeared. Since using the requirements file it installs first (separately) requirements and then orange-widget-base in a separate step. Since readthedocs use eager upgrade strategy it upgrades docuitls to newest even it is pinned by spihnx when installing orange-widget-base.
I removed requirements-rtd.txt and put rtd requirements in `EXTRAS_REQUIRE` when installing with .[doc] installation happens in the same step and the problem with forcing docutils to upgrade is solved.

##### Includes
- [ ] Code changes
- [ ] Tests
- [x] Documentation
