### PR TITLE
discovery: Preserve `category` if a widget defines it

### DIFF
--- a/orangewidget/workflow/discovery.py
+++ b/orangewidget/workflow/discovery.py
@@ -1,6 +1,3 @@
-import copy
-from itertools import chain
-
 from orangecanvas.registry import WidgetDescription
 from orangecanvas.registry import discovery
 
@@ -28,13 +25,6 @@ def widget_desc_from_module(module):
     if isinstance(module, str):
         module = __import__(module, fromlist=[""])
 
-    if module.__package__:
-        package_name = module.__package__.rsplit(".", 1)[-1]
-    else:
-        package_name = None
-
-    default_cat_name = package_name if package_name else ""
-
     for widget_class in module.__dict__.values():
         if not hasattr(widget_class, "get_widget_description"):
             continue
@@ -44,7 +34,7 @@ def widget_desc_from_module(module):
 
         description = WidgetDescription(**description)
         description.package = module.__package__
-        description.category = widget_class.category or default_cat_name
+        description.category = widget_class.category
         return description
 
     raise discovery.WidgetSpecificationError
@@ -63,7 +53,7 @@ class WidgetDiscovery(discovery.WidgetDiscovery):
         if widget_name is not None:
             desc.name = widget_name
 
-        if category_name is not None:
+        if category_name is not None and desc.category is None:
             desc.category = category_name
 
         if distribution is not None:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Related to: https://github.com/biolab/orange3/issues/5370

##### Description of changes

Preserve category if a widget defines it. Remove some weird leftover logic from Orange 2.7

Previously `OWBaseWidget.category` would only be used when the widget was registered explicitly via setup tools entry point like:
```
entry_points = {"orange.widgets": ("SomeWidget = some.package.widgets.OWSomeWidget")}
```
as apposed to via a containing 'category package'. Now `category` should be respected even if/when discovered via a category package.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
