### PR TITLE
gui.hSlider: Right-align the label, expose box and label

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -1383,13 +1383,14 @@ def hSlider(widget, master, value, box=None, minValue=0, maxValue=10, step=1,
         slider.setTickInterval(ticks)
 
     if createLabel:
-        label = QLabel(sliderBox)
+        slider.label = label = QLabel(sliderBox)
         sliderBox.layout().addWidget(label)
         label.setText(labelFormat % minValue)
         width1 = label.sizeHint().width()
         label.setText(labelFormat % maxValue)
         width2 = label.sizeHint().width()
         label.setFixedSize(max(width1, width2), label.sizeHint().height())
+        label.setAlignment(Qt.AlignRight)
         txt = labelFormat % (getdeepattr(master, value) / divideFactor)
         label.setText(txt)
         label.setLbl = lambda x: \
@@ -1405,6 +1406,7 @@ def hSlider(widget, master, value, box=None, minValue=0, maxValue=10, step=1,
         slider.sliderReleased.connect(dn.notify_immediately)
 
     miscellanea(slider, sliderBox, widget, **misc)
+    slider.box = sliderBox
     return slider
 
 


### PR DESCRIPTION
##### Issue

- Labels are currently centered; this makes the right margin rugged (i.e. not aligned with other widgets in control area or the box). These labels are numbers so aligning to the right would make more sense.
- Most function in gui expose the box in widget the control is put. `hSlider` does not. It also does not expose the label, which prevents the caller from, for instance, setting its width. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
