### PR TITLE
Remove deprecation warnings due to QKeyboardSequence

### DIFF
--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -339,7 +339,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             self.set_basic_layout()
             self.update_summaries()
 
-        sc = QShortcut(QKeySequence(Qt.ShiftModifier | Qt.Key_F1), self)
+        sc = QShortcut(QKeySequence("Shift+F1"), self)
         sc.activated.connect(self.__quicktip)
 
         sc = QShortcut(QKeySequence.Copy, self)
@@ -354,7 +354,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                 self.__toggleControlArea
             )
             sc = QShortcut(
-                QKeySequence(Qt.ControlModifier | Qt.ShiftModifier | Qt.Key_D),
+                QKeySequence("Ctrl+Shift+D"),
                 self, autoRepeat=False)
             sc.activated.connect(self.__toggleControlArea)
         return self
@@ -646,8 +646,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                 "Show status bar", self, objectName="action-show-status-bar",
                 toolTip="Show status bar", checkable=True,
                 enabled=False, visible=False,
-                shortcut=QKeySequence(
-                    Qt.ShiftModifier | Qt.ControlModifier | Qt.Key_Backslash)
+                shortcut=QKeySequence("Shift+Ctrl+\\")
             )
             statusbar_action.toggled[bool].connect(statusbar.setVisible)
             self.addAction(statusbar_action)

--- a/orangewidget/workflow/mainwindow.py
+++ b/orangewidget/workflow/mainwindow.py
@@ -57,7 +57,7 @@ class OWCanvasMainWindow(CanvasMainWindow):
             "Show report", self,
             objectName="action-show-report",
             toolTip="Show a report window",
-            shortcut=QKeySequence(Qt.ShiftModifier | Qt.Key_R),
+            shortcut=QKeySequence("Shift+R"),
             enabled=HAVE_REPORT,
         )
         self.show_report_action.triggered.connect(self.show_report_view)


### PR DESCRIPTION
##### Issue
Tests print lots of warnings like:

DeprecationWarning: an integer is required (got type KeyboardModifiers).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python