### PR TITLE
[FIX] widget: Account for control area visibility in splitter width hint

### DIFF
--- a/orangewidget/tests/test_widget.py
+++ b/orangewidget/tests/test_widget.py
@@ -127,6 +127,18 @@ class WidgetTestCase(WidgetTest):
         self.assertFalse((w2.restoreGeometryAndLayoutState(QByteArray())))
         self.assertFalse(w2.restoreGeometryAndLayoutState(QByteArray(b'ab')))
 
+    def test_resizing_disabled_width_hint(self):
+        class TestWidget(OWBaseWidget):
+            name = "Test"
+            resizing_enabled = False
+            want_main_area = True
+        w = TestWidget()
+        w._OWBaseWidget__setControlAreaVisible(False)
+        sm1 = w.maximumSize()
+        w._OWBaseWidget__setControlAreaVisible(True)
+        sm2 = w.maximumSize()
+        self.assertLess(sm1.width() + 30, sm2.width())
+
     def test_garbage_collect(self):
         widget = MyWidget()
         ref = weakref.ref(widget)

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -400,7 +400,6 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             self.setHandleWidth(18)
 
         def _adjusted_size(self, size_method):
-            size = size_method(super())()
             parent = self.parentWidget()
             if isinstance(parent, OWBaseWidget) \
                     and not parent.controlAreaVisible \
@@ -408,12 +407,11 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                 indices = range(1, self.count())
             else:
                 indices = range(0, self.count())
-
-            height = max((size_method(self.widget(i))().height()
-                          for i in indices),
-                         default=0)
-            size.setHeight(height)
-            return size
+            shs = [size_method(self.widget(i))() for i in indices]
+            height = max((sh.height() for sh in shs), default=0)
+            width = sum(sh.width() for sh in shs)
+            width += max(0, self.handleWidth() * (self.count() - 1))
+            return QSize(width, height)
 
         def sizeHint(self):
             return self._adjusted_size(attrgetter("sizeHint"))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes https://github.com/biolab/orange3/issues/5870

##### Description of changes

Account for control area visibility in splitter width hint

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
