### PR TITLE
[FIX] webview: Fix argument type

### DIFF
--- a/orangewidget/utils/webview.py
+++ b/orangewidget/utils/webview.py
@@ -240,7 +240,7 @@ if HAVE_WEBKIT:
             if debug:
                 settings.setAttribute(settings.LocalStorageEnabled, True)
                 settings.setAttribute(settings.DeveloperExtrasEnabled, True)
-                settings.setObjectCacheCapacities(4e6, 4e6, 4e6)
+                settings.setObjectCacheCapacities(int(4e6), int(4e6), int(4e6))
                 settings.enablePersistentStorage()
 
         def runJavaScript(self, javascript, resultCallback=None):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
```
File ".../orange-widget-base/orangewidget/utils/webview.py", line 243, in __init__
    settings.setObjectCacheCapacities(4e6, 4e6, 4e6)
TypeError: setObjectCacheCapacities(int, int, int): argument 1 has unexpected type 'float'
```

##### Description of changes
At some point the above function stopped accepting floats for its int parameters.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
