### PR TITLE
[FIX] itemdelegate: Fix text cache when elision takes place

### DIFF
--- a/orangewidget/utils/itemdelegates.py
+++ b/orangewidget/utils/itemdelegates.py
@@ -471,8 +471,7 @@ class DataDelegate(CachedDataItemDelegate, StyledItemDelegate):
         try:
             return self.__static_text_lru_cache[text, font, elideMode, width]
         except KeyError:
-            text = fontMetrics.elidedText(text, elideMode, width)
-            st = QStaticText(text)
+            st = QStaticText(fontMetrics.elidedText(text, elideMode, width))
             st.prepare(QTransform(), font)
             # take a copy of the font for cache key
             key = text, QFont(font), elideMode, width


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref: https://github.com/biolab/orange3/issues/5915

Improves responsiveness, when displaying long text although still not great.

##### Description of changes

Remove a temporary assignment that prevented elided text from being cached.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
