### PR TITLE
[CI] Specify full PyQt6 Qt lib version

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -39,7 +39,7 @@ jobs:
 
           - os: ubuntu-20.04
             python-version: "3.10"
-            test-env: "PyQt6~=6.2.3 PyQt6-WebEngine~=6.2.1"
+            test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3 PyQt6-WebEngine~=6.2.1 PyQt6-WebEngine-Qt6~=6.2.1"
             extra-system-packages: "libegl1-mesa"
 
           # macOS
@@ -90,7 +90,7 @@ jobs:
 
           - os: windows-2019
             python-version: "3.10"
-            test-env: "PyQt6~=6.2.3 PyQt6-WebEngine~=6.2.1"
+            test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3 PyQt6-WebEngine~=6.2.1 PyQt6-WebEngine-Qt6~=6.2.1"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Tests fail to import and segfault on windows when installing PyQt6==6.2.* and PyQt6-Qt6==6.3.*

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
