### PR TITLE
Transient preview of input and output signals

### DIFF
--- a/orangewidget/tests/test_widget.py
+++ b/orangewidget/tests/test_widget.py
@@ -16,7 +16,7 @@ from orangewidget.settings import Setting, SettingProvider
 from orangewidget.tests.base import WidgetTest
 from orangewidget.utils.signals import summarize, PartialSummary
 from orangewidget.widget import OWBaseWidget, Msg, StateInfo, Input, Output
-from orangewidget.utils.messagewidget import MessagesWidget
+from orangewidget.utils.messagewidget import InOutStateWidget
 
 
 class DummyComponent(OWComponent):
@@ -434,45 +434,40 @@ class WidgetTestInfoSummary(WidgetTest):
     def test_io_summaries(self):
         w = MyWidget()
         info = w.info  # type: StateInfo
-        inmsg = w.findChild(MessagesWidget, "input-summary")  # type: MessagesWidget
-        outmsg = w.findChild(MessagesWidget, "output-summary")  # type: MessagesWidget
-        self.assertEqual(len(inmsg.messages()), 0)
-        self.assertEqual(len(outmsg.messages()), 0)
+        inmsg: InOutStateWidget = w.findChild(InOutStateWidget, "input-summary")
+        outmsg: InOutStateWidget = w.findChild(InOutStateWidget, "output-summary")
+        self.assertFalse(inmsg.message)
+        self.assertFalse(outmsg.message)
 
         w.info.set_input_summary(w.info.NoInput)
         w.info.set_output_summary(w.info.NoOutput)
-
-        self.assertEqual(len(inmsg.messages()), 1)
-        self.assertFalse(inmsg.summarize().isEmpty())
-        self.assertEqual(len(outmsg.messages()), 1)
-        self.assertFalse(outmsg.summarize().isEmpty())
+        self.assertTrue(inmsg.message.text)
+        self.assertTrue(outmsg.message.text)
 
         info.set_input_summary("Foo")
 
-        self.assertEqual(len(inmsg.messages()), 1)
-        self.assertEqual(inmsg.summarize().text, "Foo")
-        self.assertFalse(inmsg.summarize().icon.isNull())
+        self.assertTrue(inmsg.message)
+        self.assertEqual(inmsg.message.text, "Foo")
 
         info.set_input_summary(12_345)
         info.set_output_summary(1234)
 
-        self.assertEqual(inmsg.summarize().text, "12.3k")
-        self.assertEqual(inmsg.summarize().informativeText, "12345")
-        self.assertEqual(outmsg.summarize().text, "1234")
+        self.assertEqual(inmsg.message.text, "12.3k")
+        self.assertEqual(inmsg.message.informativeText, "12345")
+        self.assertEqual(outmsg.message.text, "1234")
 
         info.set_input_summary("Foo", "A foo that bars",)
 
         info.set_input_summary(None)
         info.set_output_summary(None)
 
-        self.assertTrue(inmsg.summarize().isEmpty())
-        self.assertTrue(outmsg.summarize().isEmpty())
+        self.assertFalse(inmsg.message.text)
+        self.assertFalse(outmsg.message.text)
 
         info.set_output_summary("Foobar", "42")
 
-        self.assertEqual(len(outmsg.messages()), 1)
-        self.assertEqual(outmsg.summarize().text, "Foobar")
-        self.assertFalse(outmsg.summarize().icon.isNull())
+        self.assertTrue(outmsg.message)
+        self.assertEqual(outmsg.message.text, "Foobar")
 
         with self.assertRaises(TypeError):
             info.set_input_summary(None, "a")
@@ -489,10 +484,10 @@ class WidgetTestInfoSummary(WidgetTest):
         info.set_input_summary(1234, "Foo")
         info.set_output_summary(1234, "Bar")
 
-        self.assertEqual(inmsg.summarize().text, "1234")
-        self.assertEqual(inmsg.summarize().informativeText, "Foo")
-        self.assertEqual(outmsg.summarize().text, "1234")
-        self.assertEqual(outmsg.summarize().informativeText, "Bar")
+        self.assertEqual(inmsg.message.text, "1234")
+        self.assertEqual(inmsg.message.informativeText, "Foo")
+        self.assertEqual(outmsg.message.text, "1234")
+        self.assertEqual(outmsg.message.informativeText, "Bar")
 
     def test_format_number(self):
         self.assertEqual(StateInfo.format_number(9999), "9999")

--- a/orangewidget/utils/messagewidget.py
+++ b/orangewidget/utils/messagewidget.py
@@ -103,6 +103,9 @@ class Message(
         return super().__new__(cls, Severity(severity), QIcon(icon), text,
                                informativeText, detailedText, textFormat)
 
+    def __bool__(self):
+        return not self.isEmpty()
+
     def asHtml(self, includeShortText=True):
         # type: () -> str
         """
@@ -338,13 +341,11 @@ class ElidingLabel(QLabel):
             super().setText(self.__originalText)
 
 
-class MessagesWidget(QWidget):
+class MessageWidget(QWidget):
     """
-    An iconified multiple message display area.
+    An iconified message display area.
 
-    `MessagesWidget` displays a short message along with an icon. If there
-    are multiple messages they are summarized. The user can click on the
-    widget to display the full message text in a popup view.
+    `IconifiedMessage` displays a short message along with an icon.
     """
     #: Signal emitted when an embedded html link is clicked
     #: (if `openExternalLinks` is `False`).
@@ -352,14 +353,6 @@ class MessagesWidget(QWidget):
 
     #: Signal emitted when an embedded html link is hovered.
     linkHovered = Signal(str)
-
-    Severity = Severity
-    #: General informative message.
-    Information = Severity.Information
-    #: A warning message severity.
-    Warning = Severity.Warning
-    #: An error message severity.
-    Error = Severity.Error
 
     Message = Message
 
@@ -370,11 +363,10 @@ class MessagesWidget(QWidget):
             QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
         )
         super().__init__(parent, **kwargs)
-        self.__openExternalLinks = openExternalLinks  # type: bool
-        self.__messages = OrderedDict()  # type: Dict[Hashable, Message]
+        self._openExternalLinks = openExternalLinks  # type: bool
         #: The full (joined all messages text - rendered as html), displayed
         #: in a tooltip.
-        self.__fulltext = ""
+        self.message = None
         #: Leading icon
         self.__iconwidget = IconWidget(
             sizePolicy=QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
@@ -383,7 +375,7 @@ class MessagesWidget(QWidget):
         self.__textlabel = ElidingLabel(
             wordWrap=False,
             textInteractionFlags=Qt.LinksAccessibleByMouse,
-            openExternalLinks=self.__openExternalLinks,
+            openExternalLinks=self._openExternalLinks,
             sizePolicy=QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Minimum),
             elide=elideText
         )
@@ -407,17 +399,30 @@ class MessagesWidget(QWidget):
         self.anim.setEasingCurve(QEasingCurve.OutQuad)
         self.anim.setLoopCount(2)
 
+    def setMessage(self, message):
+        self.message = message
+        self.ensurePolished()
+        icon = message_icon(message)
+        self.__iconwidget.setIcon(icon)
+        self.__iconwidget.setVisible(not (message.isEmpty() or icon.isNull()))
+        self.__textlabel.setTextFormat(message.textFormat)
+        self.__textlabel.setText(message.text)
+        self.__textlabel.setVisible(bool(message.text))
+        self.setToolTip(self._styled(message.asHtml()))
+        self.anim.start(QPropertyAnimation.KeepWhenStopped)
+        self.layout().activate()
+
     def sizeHint(self):
         sh = super().sizeHint()
         h = self.style().pixelMetric(QStyle.PM_SmallIconSize)
-        if all(m.isEmpty() for m in self.messages()):
+        if not self.message:
             sh.setWidth(0)
         return sh.expandedTo(QSize(0, h + 2))
 
     def minimumSizeHint(self):
         msh = super().minimumSizeHint()
         h = self.style().pixelMetric(QStyle.PM_SmallIconSize)
-        if all(m.isEmpty() for m in self.messages()):
+        if not self.message:
             msh.setWidth(0)
         else:
             msh.setWidth(h + 2)
@@ -431,14 +436,14 @@ class MessagesWidget(QWidget):
         using `QDesktopServices.openUrl`
         """
         # TODO: update popup if open
-        self.__openExternalLinks = state
+        self._openExternalLinks = state
         self.__textlabel.setOpenExternalLinks(state)
 
     def openExternalLinks(self):
         # type: () -> bool
         """
         """
-        return self.__openExternalLinks
+        return self._openExternalLinks
 
     def setDefaultStyleSheet(self, css):
         # type: (str) -> None
@@ -463,7 +468,6 @@ class MessagesWidget(QWidget):
         """
         if self.__defaultStyleSheet != css:
             self.__defaultStyleSheet = css
-            self.__update()
 
     def defaultStyleSheet(self):
         """
@@ -473,6 +477,85 @@ class MessagesWidget(QWidget):
             The current style sheet
         """
         return self.__defaultStyleSheet
+
+    def flashIcon(self):
+        self.anim.start(QPropertyAnimation.KeepWhenStopped)
+
+    def _styled(self, html):
+        # Prepend css style sheet before a html fragment.
+        if self.__defaultStyleSheet.strip():
+            return f"<style>{escape(self.__defaultStyleSheet)}</style>\n{html}"
+        else:
+            return html
+
+    def enterEvent(self, event):
+        super().enterEvent(event)
+        self.update()
+
+    def leaveEvent(self, event):
+        super().leaveEvent(event)
+        self.update()
+
+    def changeEvent(self, event):
+        super().changeEvent(event)
+        self.update()
+
+    def paintEvent(self, event):
+        opt = QStyleOption()
+        opt.initFrom(self)
+        if not self.message:
+            return
+
+        if not (opt.state & QStyle.State_MouseOver or
+                opt.state & QStyle.State_HasFocus):
+            return
+
+        palette = opt.palette  # type: QPalette
+        if opt.state & QStyle.State_HasFocus:
+            pen = QPen(palette.color(QPalette.Highlight))
+        else:
+            pen = QPen(palette.color(QPalette.Dark))
+
+        if self.message and \
+                opt.state & QStyle.State_MouseOver and \
+                opt.state & QStyle.State_Active:
+            g = QLinearGradient()
+            g.setCoordinateMode(QLinearGradient.ObjectBoundingMode)
+            base = palette.color(QPalette.Window)
+            base.setAlpha(90)
+            g.setColorAt(0, base.lighter(200))
+            g.setColorAt(0.6, base)
+            g.setColorAt(1.0, base.lighter(200))
+            brush = QBrush(g)
+        else:
+            brush = QBrush(Qt.NoBrush)
+        p = QPainter(self)
+        p.setBrush(brush)
+        p.setPen(pen)
+        p.drawRect(opt.rect.adjusted(0, 0, -1, -1))
+
+
+class MessagesWidget(MessageWidget):
+    """
+    An iconified multiple message display area.
+
+    `MessagesWidget` displays a short message along with an icon. If there
+    are multiple messages they are summarized. The user can click on the
+    widget to display the full message text in a popup view.
+    """
+    Severity = Severity
+    #: General informative message.
+    Information = Severity.Information
+    #: A warning message severity.
+    Warning = Severity.Warning
+    #: An error message severity.
+    Error = Severity.Error
+
+    def __init__(self, parent=None, openExternalLinks=False, elideText=False,
+                 defaultStyleSheet="", **kwargs):
+        super().__init__(parent, openExternalLinks, elideText,
+                         defaultStyleSheet, **kwargs)
+        self.__messages = OrderedDict()  # type: Dict[Hashable, Message]
 
     def setMessage(self, message_id, message):
         # type: (Hashable, Message) -> None
@@ -547,54 +630,20 @@ class MessagesWidget(QWidget):
                 self.anim.start(QPropertyAnimation.KeepWhenStopped)
                 break
 
-    @staticmethod
-    def __styled(css, html):
-        # Prepend css style sheet before a html fragment.
-        if css.strip():
-            return "<style>\n" + escape(css) + "\n</style>\n" + html
-        else:
-            return html
-
     def __update(self):
-        """
-        Update the current display state.
-        """
-        self.ensurePolished()
-        summary = self.summarize()
-        icon = message_icon(summary)
-        self.__iconwidget.setIcon(icon)
-        self.__iconwidget.setVisible(not (summary.isEmpty() or icon.isNull()))
-        self.__textlabel.setTextFormat(summary.textFormat)
-        self.__textlabel.setText(summary.text)
-        self.__textlabel.setVisible(bool(summary.text))
-
-        def is_short(m):
-            return not (m.informativeText or m.detailedText)
-
-        messages = [m for m in self.__messages.values() if not m.isEmpty()]
-        if not messages:
-            fulltext = ""
-        else:
-            messages = sorted(messages, key=attrgetter("severity"),
-                              reverse=True)
-            fulltext = "<hr/>".join(m.asHtml() for m in messages)
-        self.__fulltext = fulltext
-        self.setToolTip(self.__styled(self.__defaultStyleSheet, fulltext))
-        self.anim.start(QPropertyAnimation.KeepWhenStopped)
-
-        self.layout().activate()
+        super().setMessage(self.summarize())
 
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
-            if self.__fulltext:
+            message = self.message
+            if message and (message.detailedText or message.informativeText):
                 popup = QMenu(self)
                 label = QLabel(
                     self, textInteractionFlags=Qt.TextBrowserInteraction,
-                    openExternalLinks=self.__openExternalLinks,
+                    openExternalLinks=self._openExternalLinks,
                 )
                 label.setContentsMargins(4, 4, 4, 4)
-                label.setText(self.__styled(self.__defaultStyleSheet,
-                                            self.__fulltext))
+                label.setText(self._styled(message.asHtml()))
 
                 label.linkActivated.connect(self.linkActivated)
                 label.linkHovered.connect(self.linkHovered)
@@ -606,52 +655,6 @@ class MessagesWidget(QWidget):
             return
         else:
             super().mousePressEvent(event)
-
-    def enterEvent(self, event):
-        super().enterEvent(event)
-        self.update()
-
-    def leaveEvent(self, event):
-        super().leaveEvent(event)
-        self.update()
-
-    def changeEvent(self, event):
-        super().changeEvent(event)
-        self.update()
-
-    def paintEvent(self, event):
-        opt = QStyleOption()
-        opt.initFrom(self)
-        if not self.__fulltext:
-            return
-
-        if not (opt.state & QStyle.State_MouseOver or
-                opt.state & QStyle.State_HasFocus):
-            return
-
-        palette = opt.palette  # type: QPalette
-        if opt.state & QStyle.State_HasFocus:
-            pen = QPen(palette.color(QPalette.Highlight))
-        else:
-            pen = QPen(palette.color(QPalette.Dark))
-
-        if self.__fulltext and \
-                opt.state & QStyle.State_MouseOver and \
-                opt.state & QStyle.State_Active:
-            g = QLinearGradient()
-            g.setCoordinateMode(QLinearGradient.ObjectBoundingMode)
-            base = palette.color(QPalette.Window)
-            base.setAlpha(90)
-            g.setColorAt(0, base.lighter(200))
-            g.setColorAt(0.6, base)
-            g.setColorAt(1.0, base.lighter(200))
-            brush = QBrush(g)
-        else:
-            brush = QBrush(Qt.NoBrush)
-        p = QPainter(self)
-        p.setBrush(brush)
-        p.setPen(pen)
-        p.drawRect(opt.rect.adjusted(0, 0, -1, -1))
 
 
 class IconWidget(QWidget):

--- a/orangewidget/utils/messagewidget.py
+++ b/orangewidget/utils/messagewidget.py
@@ -636,7 +636,7 @@ class MessagesWidget(MessageWidget):
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
             message = self.message
-            if message and (message.detailedText or message.informativeText):
+            if message:
                 popup = QMenu(self)
                 label = QLabel(
                     self, textInteractionFlags=Qt.TextBrowserInteraction,
@@ -656,6 +656,17 @@ class MessagesWidget(MessageWidget):
         else:
             super().mousePressEvent(event)
 
+
+class InOutStateWidget(MessageWidget):
+    clicked = Signal()
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self.clicked.emit()
+            event.accept()
+            return
+        else:
+            super().mousePressEvent(event)
 
 class IconWidget(QWidget):
     """

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -3,6 +3,7 @@ import os
 import types
 import warnings
 import textwrap
+from functools import partial
 from operator import attrgetter
 from math import log10
 
@@ -24,7 +25,7 @@ from orangewidget.gui import OWComponent, VerticalScrollArea
 from orangewidget.io import ClipboardFormat, ImgFormat
 from orangewidget.settings import SettingsHandler
 from orangewidget.utils import saveplot, getdeepattr
-from orangewidget.utils.messagewidget import MessageWidget
+from orangewidget.utils.messagewidget import InOutStateWidget
 from orangewidget.utils.progressbar import ProgressBarMixin
 from orangewidget.utils.messages import (
     WidgetMessagesMixin, UnboundMsg, MessagesWidget
@@ -760,18 +761,20 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
             sb = self.statusBar()
             if sb is not None:
-                in_msg = MessageWidget(
+                in_msg = InOutStateWidget(
                     objectName="input-summary", visible=False,
                     defaultStyleSheet=css,
                     sizePolicy=QSizePolicy(QSizePolicy.Fixed,
                                            QSizePolicy.Fixed)
                 )
-                out_msg = MessageWidget(
+                out_msg = InOutStateWidget(
                     objectName="output-summary", visible=False,
                     defaultStyleSheet=css,
                     sizePolicy=QSizePolicy(QSizePolicy.Fixed,
                                            QSizePolicy.Fixed)
                 )
+                in_msg.clicked.connect(partial(self.show_preview, self.input_summaries))
+                out_msg.clicked.connect(partial(self.show_preview, self.output_summaries))
 
                 in_out_msg = sb.findChild(QWidget, "in-out-msg")
 

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -24,6 +24,7 @@ from orangewidget.gui import OWComponent, VerticalScrollArea
 from orangewidget.io import ClipboardFormat, ImgFormat
 from orangewidget.settings import SettingsHandler
 from orangewidget.utils import saveplot, getdeepattr
+from orangewidget.utils.messagewidget import MessageWidget
 from orangewidget.utils.progressbar import ProgressBarMixin
 from orangewidget.utils.messages import (
     WidgetMessagesMixin, UnboundMsg, MessagesWidget
@@ -759,13 +760,13 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
             sb = self.statusBar()
             if sb is not None:
-                in_msg = MessagesWidget(
+                in_msg = MessageWidget(
                     objectName="input-summary", visible=False,
                     defaultStyleSheet=css,
                     sizePolicy=QSizePolicy(QSizePolicy.Fixed,
                                            QSizePolicy.Fixed)
                 )
-                out_msg = MessagesWidget(
+                out_msg = MessageWidget(
                     objectName="output-summary", visible=False,
                     defaultStyleSheet=css,
                     sizePolicy=QSizePolicy(QSizePolicy.Fixed,
@@ -791,7 +792,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                         icon=m.icon, text=m.brief, informativeText=m.details,
                         textFormat=m.format
                     )
-                    msgwidget.setMessage(0, message)
+                    msgwidget.setMessage(message)
                     msgwidget.setVisible(not message.isEmpty())
 
                 info.input_summary_changed.connect(


### PR DESCRIPTION
##### Issue

Provide previewers for input and output signals.

##### Description of changes

- Refactor `MessageWidget` into a widget with a single message and a derived widget that composes a message from multiple messages (the current functionality)
- Derive a new class for messages showing input and output
- Add previewers for signals: `PartialSummary` has a new attribute for a callback that provides a preview widget

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
