### PR TITLE
GuiTest: Undo pyqtgraph's excepthook override

### DIFF
--- a/doc/requirements-rtd.txt
+++ b/doc/requirements-rtd.txt
@@ -1,7 +1,7 @@
 --only-binary PyQt5,matplotlib
 
 setuptools
-sphinx>=4.2.0
+sphinx~=4.2.0
 AnyQt
 PyQt5~=5.12.1
 PyQtWebengine~=5.12.1

--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -181,6 +181,10 @@ class GuiTest(unittest.TestCase):
             else:
                 appnope.nope()
         cls.tear_down_stack = ExitStack()
+        if "pyqtgraph" in sys.modules:
+            # undo pyqtgraph excepthook override, abort on exceptions in
+            # slots, event handlers, ...
+            sys.excepthook = sys.__excepthook__
         super().setUpClass()
 
     @classmethod

--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -196,6 +196,14 @@ class GuiTest(unittest.TestCase):
         super().tearDownClass()
         QTest.qWait(0)
 
+    def tearDown(self) -> None:
+        """
+        Process any pending events before the next test is executed. This
+        includes deletes scheduled with `QObject.deleteLater`.
+        """
+        super().tearDown()
+        QTest.qWait(0)
+
 
 class WidgetTest(GuiTest):
     """Base class for widget tests
@@ -274,7 +282,6 @@ class WidgetTest(GuiTest):
     def tearDown(self):
         """Process any pending events before the next test is executed."""
         self.signal_manager.clear()
-        QTest.qWait(0)
         super().tearDown()
 
     def create_widget(self, cls, stored_settings=None, reset_default_settings=True):

--- a/orangewidget/tests/test_gui.py
+++ b/orangewidget/tests/test_gui.py
@@ -229,12 +229,11 @@ class TestDateTimeEditWCalendarTime(GuiTest):
         self.assertEqual(c.dateTime(), poeh)
 
 
-class TestDeferred(GuiTest):
+class TestDeferred(WidgetTest):
     def test_deferred(self) -> None:
         class Widget(OWBaseWidget):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
-
                 self.option = False
                 self.autocommit = False
 
@@ -247,9 +246,10 @@ class TestDeferred(GuiTest):
             real_apply = Mock()
             # Unlike real functions, mocks don't have names
             real_apply.__name__ = "apply"
+
             apply = gui.deferred(real_apply)
 
-        w = Widget()
+        w = self.create_widget(Widget)
 
         # clicked, but no autocommit
         w.checkbox.click()
@@ -282,7 +282,7 @@ class TestDeferred(GuiTest):
         # calling decorated method without `now` or `deferred` raises an expception
         self.assertRaises(RuntimeError, w.apply)
 
-        w2 = Widget()
+        w2 = self.create_widget(Widget)
         w.apply.now()
         w.real_apply.assert_called_with(w)
         w.real_apply.reset_mock()
@@ -291,6 +291,7 @@ class TestDeferred(GuiTest):
         class Widget(OWBaseWidget):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
+
                 self.autocommit = False
                 self.commit_button = gui.auto_commit(
                     self, self, 'autocommit', 'Commit')
@@ -299,7 +300,7 @@ class TestDeferred(GuiTest):
                 pass
 
         with self.assertWarns(UserWarning):
-            _ = Widget()
+            _ = self.create_widget(Widget)
 
     def test_override(self):
         class Widget(OWBaseWidget, openclass=True):
@@ -322,7 +323,7 @@ class TestDeferred(GuiTest):
                 super().commit()
                 self.n()
 
-        w = Widget2()
+        w = self.create_widget(Widget2)
         w.commit.now()
         w.m.assert_called_once()
         w.n.assert_called_once()
@@ -334,7 +335,7 @@ class TestDeferred(GuiTest):
             def commit(self):
                 self.n()
 
-        w = Widget3()
+        w = self.create_widget(Widget3)
         w.commit.now()
         w.m.assert_not_called()
         w.n.assert_called_once()
@@ -346,7 +347,7 @@ class TestDeferred(GuiTest):
             def commit(self):
                 self.n()
 
-        self.assertRaises(RuntimeError, Widget4)
+        self.assertRaises(RuntimeError, lambda: self.create_widget(Widget4))
 
     def test_override_and_decorate(self):
         class Widget(OWBaseWidget, openclass=True):
@@ -368,7 +369,7 @@ class TestDeferred(GuiTest):
                 super().commit()
                 self.n()
 
-        w = Widget2()
+        w = self.create_widget(Widget2)
         w.commit.deferred()
         w.m.assert_not_called()
         w.n.assert_not_called()
@@ -400,7 +401,7 @@ class TestDeferred(GuiTest):
             def magog(self):
                 self.real_magog()
 
-        w = Widget()
+        w = self.create_widget(Widget)
 
         # Make a deffered call to commit; nothing should be called
         w.commit.deferred()

--- a/orangewidget/utils/tests/test_signals.py
+++ b/orangewidget/utils/tests/test_signals.py
@@ -10,7 +10,7 @@ from unittest.mock import patch, MagicMock
 
 from orangewidget.widget import \
     Single, Multiple, Default, NonDefault, Explicit, Dynamic
-from orangewidget.tests.base import GuiTest
+from orangewidget.tests.base import WidgetTest
 from orangewidget.utils.signals import _Signal, Input, Output, \
     WidgetSignalsMixin, InputSignal, OutputSignal, MultiInput, summarize, \
     PartialSummary
@@ -101,14 +101,14 @@ class OutputTest(unittest.TestCase):
             widget, "a name", value, id)
 
 
-class WidgetSignalsMixinTest(GuiTest):
+class WidgetSignalsMixinTest(WidgetTest):
     def test_init_binds_outputs(self):
         class MockWidget(OWBaseWidget):
             name = "foo"
             class Outputs:
                 an_output = Output("a name", int)
 
-        widget = MockWidget()
+        widget = self.create_widget(MockWidget)
         self.assertEqual(widget.Outputs.an_output.widget, widget)
         self.assertIsNone(MockWidget.Outputs.an_output.widget)
 
@@ -231,7 +231,7 @@ class WidgetSignalsMixinTest(GuiTest):
             @Inputs.input_a.remove
             def remove_a(self, index):
                 pass
-        w = TestWidget()
+        w = self.create_widget(TestWidget)
         w.insert_a(0, Str("00"))
         w.insert_a(1, Str("11"))
         self.assertSequenceEqual(

--- a/orangewidget/workflow/tests/test_widgetsscheme.py
+++ b/orangewidget/workflow/tests/test_widgetsscheme.py
@@ -277,7 +277,7 @@ class TestWidgetManager(GuiTest):
 
     def test_state_init(self):
         def __init__(self, *args, **kwargs):
-            super(widget.OWBaseWidget, self).__init__(*args, **kwargs)
+            super(Adder, self).__init__(*args, **kwargs)
             self.setReady(False)
             self.setInvalidated(True)
             self.progressBarInit()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

pyqtgraph installs a `sys.excepthook` to suppress errors in slots/event handlers. This can mask errors in tests which happen in Qt invoked slots/event handlers, ...

Reset the `sys.excepthook` to let the test abort on error. 

##### Description of changes

Undo pyqtgraph's excepthook override, let the program abort on unhandled exception in a slot, event handler, ...

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
