### PR TITLE
Sphinx: Set language

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -79,7 +79,7 @@ release = dist.version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
##### Issue

Sphinx fails because language is not set (this is a warning, but `-W` elevates it into an error).

##### Description of changes

Set language to `"en"`.

##### Includes
- [X] Code changes
