### PR TITLE
PyListModel: Fix Separator's flags

### DIFF
--- a/orangewidget/utils/tests/test_itemmodels.py
+++ b/orangewidget/utils/tests/test_itemmodels.py
@@ -624,6 +624,15 @@ class TestPyListModel(unittest.TestCase):
         r = model.moveRows(QModelIndex(), 0, 0, QModelIndex(), 0)
         self.assertIs(r, False)
 
+    def test_separator(self):
+        model = PyListModel([1, PyListModel.Separator, 2])
+        model.append(model.Separator)
+        model += [1, model.Separator]
+        model.extend([1, model.Separator])
+        for i in range(len(model)):
+            self.assertIs(model.flags(model.index(i)) == Qt.NoItemFlags,
+                          i % 2 != 0, f"in row {i}")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue

For `PyListModel`, separators work properly only if inserted/set via `__setitem__`, e.g. `model[len(self.x_model):] = [PyListModel.Separator]`. Meanwhile, `model.append(PyListModel.Separator)` inserts an empty item (which can be even selected).

##### Description of changes

The problem occurs because only `__setitem__` properly sets the corresponding flag entry. Instead of adding similar code to all other places that can add a separator, this PR fixes methods `setData` and `flags` to return the proper data for separators.

For backward compatibility (with what?) setting any other flag overrides the flag for separator.
 
##### Includes
- [X] Code changes
- [X] Tests