### PR TITLE
[MNT][CI] Add libxcb-shape to linux system packages

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -43,27 +43,23 @@ jobs:
             extra-system-packages: "libegl1-mesa"
 
           # macOS
-          - os: macos-10.15
-            python-version: 3.6
-            test-env: "PyQt5~=5.9.2"
-
-          - os: macos-10.15
+          - os: macos-11
             python-version: 3.7
             test-env: "PyQt5~=5.12.1 PyQtWebEngine~=5.12.1"
 
-          - os: macos-10.15
+          - os: macos-11
             python-version: 3.8
             test-env: "PyQt5~=5.14.0 PyQtWebEngine~=5.14.0"
 
-          - os: macos-10.15
+          - os: macos-11
             python-version: 3.9
             test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0"
 
-          - os: macos-10.15
+          - os: macos-12
             python-version: "3.10"
             test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0"
 
-          - os: macos-10.15
+          - os: macos-12
             python-version: "3.10"
             test-env: "PyQt6~=6.2.3 PyQt6-WebEngine~=6.2.1"
 

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -106,7 +106,7 @@ jobs:
         # https://www.riverbankcomputing.com/pipermail/pyqt/2020-June/042949.html
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 $PACKAGES
+          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libxcb-shape0 $PACKAGES
 
       - name: Setup Pip Cache
         uses: actions/cache@v2


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Linux gh actions runners started failing with 'qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.'

##### Description of changes

Add libxcb-shape to installed linux system packages
Also update deprecated macos-10.15 runners

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
