### PR TITLE
[FIX] widget: Remove Qt.MSWindowsFixedSizeDialogHint flag

### DIFF
--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -391,8 +391,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
     @classmethod
     def get_flags(cls):
-        return (Qt.Window if cls.resizing_enabled
-                else Qt.Dialog | Qt.MSWindowsFixedSizeDialogHint)
+        return Qt.Window if cls.resizing_enabled else Qt.Dialog
 
     class _Splitter(QSplitter):
         handleClicked = Signal()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes: https://github.com/biolab/orange3/issues/6040

From Qt docs: The use of this flag is not recommended in multi-monitor
environments. This is because the system will enforce that the window
maintains its native size when moving it across screens. This is
particularly undesirable when using monitors with different
resolutions.

##### Description of changes

Remove Qt.MSWindowsFixedSizeDialogHint flag

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
