### PR TITLE
[FIX] Check box with disabled state: Block signals

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -28,7 +28,7 @@ from orangewidget.utils.combobox import (
     ComboBox as OrangeComboBox, ComboBoxSearch as OrangeComboBoxSearch
 )
 from orangewidget.utils.itemdelegates import text_color_for_state
-from orangewidget.utils.itemmodels import PyListModel
+from orangewidget.utils.itemmodels import PyListModel, signal_blocking
 
 __re_label = re.compile(r"(^|[^%])%\((?P<value>[a-zA-Z]\w*)\)")
 
@@ -860,7 +860,8 @@ class CheckBoxWithDisabledState(QtWidgets.QCheckBox):
     def changeEvent(self, event):
         super().changeEvent(event)
         if event.type() == event.EnabledChange:
-            self._updateChecked()
+            with signal_blocking(self):
+                self._updateChecked()
 
     def setCheckState(self, state):
         self.trueState = state


### PR DESCRIPTION
##### Issue

Consider the following code:

```python
        cb = gui.checkBox(
            None, self, "label_only_subset", "Show labels only for subset",
            disabled=True,
            callback=self._update_labels, stateWhenDisabled=False)
```

Suppose that `label_only_subset` is initially `True`. This will add the check box, connect the corresponding signals and, at the very end, call the checkbox's `setDisabled(True)`. This will result in a call of method `_updateChecked`, which will  call `setCheckState(False)`. Because the checkbox was initially `True`, this therefore triggers the specified callback, that is, the widget's method `_update_labels`. This fails because the widget is not fully initialized yet.

The solution proposed in this PR, blocking signals, will block all signals caused by changing the state of the checkbox. The assumption here is that the check box is disabled because the widget state (for instance, the type of data it has) is such that checking/unchecking the check box is in fact not an option: the widget essentially disregards the check box. *However*, badly(?) written widget may assume that the check box has set the attributes (in this case: `label_only_subset`) to the reasonable value and that the widget will be notified about this.

I don't know if there are indeed such widgets. If there are, the change proposed in this PR will break them.

The only alternative I see is that `gui.checkbox` would have a flag that is set only when the initialization is finished, and it would block the signals until then. Which is ugly.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
