### PR TITLE
itemmodels: Do not remap indices in fallback path

### DIFF
--- a/orangewidget/utils/itemmodels.py
+++ b/orangewidget/utils/itemmodels.py
@@ -88,13 +88,12 @@ class AbstractSortTableModel(QAbstractTableModel):
         try:
             # Call the overridden implementation if available
             data = numpy.asarray(self.sortColumnData(column))
+            data = data[self.mapToSourceRows(Ellipsis)]
         except NotImplementedError:
             # Fallback to slow implementation
             data = numpy.array([self.index(row, column).data()
                                 for row in range(self.rowCount())])
-
         assert data.ndim in (1, 2), 'Data should be 1- or 2-dimensional'
-        data = data[self.mapToSourceRows(Ellipsis)]
         return data
 
     def sortColumn(self):

--- a/orangewidget/utils/tests/test_itemmodels.py
+++ b/orangewidget/utils/tests/test_itemmodels.py
@@ -252,6 +252,19 @@ class TestAbstractSortTableModel(unittest.TestCase):
         self.assertSequenceEqual(model.mapToSourceRows(...).tolist(), [0, 2, 1])
         self.assertSequenceEqual(model.mapFromSourceRows(...).tolist(), [0, 2, 1])
 
+    def test_sorting_fallback(self):
+        class TableModel(PyTableModel):
+            def sortColumnData(self, column):
+                raise NotImplementedError
+
+        model = TableModel([[1, 4],
+                            [2, 2],
+                            [3, 3]])
+        model.sort(1, Qt.DescendingOrder)
+        self.assertSequenceEqual(model.mapToSourceRows(...).tolist(), [0, 2, 1])
+        model.sort(1, Qt.AscendingOrder)
+        self.assertSequenceEqual(model.mapToSourceRows(...).tolist(), [1, 2, 0])
+
     def test_sorting_2d(self):
         class Model(AbstractSortTableModel):
             def rowCount(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

AbstractSortTableModel does double remap in `_sortColumnData` in the fallback path when `sortColumnData` is not reimplemented.

##### Description of changes

Do not remap indices in fallback path. They are already mapped by `data()`

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
