### PR TITLE
[CI] Add Python 3.11 to test matrices

### DIFF
--- a/.github/workflows/run-docs-build.yml
+++ b/.github/workflows/run-docs-build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-18.04
-            python: 3.6
+            python: 3.8
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-docs-build.yml
+++ b/.github/workflows/run-docs-build.yml
@@ -19,14 +19,14 @@ jobs:
             python: 3.8
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
       - name: Setup Pip Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .pip-cache
           key: ${{ runner.os }}-py-${{ matrix.python }}-pip-${{ hashFiles('setup.*', '.github/workflows/run-docs-build.yml') }}

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -18,27 +18,27 @@ jobs:
         include:
           # Linux
           - os: ubuntu-20.04
-            python-version: 3.6
+            python-version: 3.7
             test-env: "PyQt5~=5.9.2"
 
           - os: ubuntu-18.04
-            python-version: 3.7
+            python-version: 3.8
             test-env: "PyQt5~=5.12.1 PyQtWebEngine~=5.12.1"
 
           - os: ubuntu-20.04
-            python-version: 3.8
+            python-version: 3.9
             test-env: "PyQt5~=5.14.0 PyQtWebEngine~=5.14.0"
 
           - os: ubuntu-20.04
-            python-version: 3.9
-            test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0"
-
-          - os: ubuntu-20.04
             python-version: "3.10"
             test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0"
 
           - os: ubuntu-20.04
-            python-version: "3.10"
+            python-version: "3.11"
+            test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0"
+
+          - os: ubuntu-20.04
+            python-version: "3.11"
             test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3 PyQt6-WebEngine~=6.2.1 PyQt6-WebEngine-Qt6~=6.2.1"
             extra-system-packages: "libegl1-mesa"
 
@@ -60,32 +60,32 @@ jobs:
             test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0"
 
           - os: macos-12
-            python-version: "3.10"
+            python-version: "3.11"
             test-env: "PyQt6~=6.2.3 PyQt6-WebEngine~=6.2.1"
 
           # Windows
           - os: windows-2019
-            python-version: 3.6
+            python-version: 3.7
             test-env: "PyQt5~=5.9.2"
 
           - os: windows-2019
-            python-version: 3.7
+            python-version: 3.8
             test-env: "PyQt5~=5.12.1 PyQtWebEngine~=5.12.1"
 
           - os: windows-2019
-            python-version: 3.8
+            python-version: 3.9
             test-env: "PyQt5~=5.14.0 PyQtWebEngine~=5.14.0 pyqtgraph>=0.11a0"
 
           - os: windows-2019
-            python-version: 3.9
-            test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0 pyqtgraph>=0.11a0"
-
-          - os: windows-2019
             python-version: "3.10"
             test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0 pyqtgraph>=0.11a0"
 
           - os: windows-2019
-            python-version: "3.10"
+            python-version: "3.11"
+            test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0 pyqtgraph>=0.11a0"
+
+          - os: windows-2019
+            python-version: "3.11"
             test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3 PyQt6-WebEngine~=6.2.1 PyQt6-WebEngine-Qt6~=6.2.1"
 
     steps:

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -74,7 +74,7 @@ jobs:
 
           - os: windows-2019
             python-version: 3.9
-            test-env: "PyQt5~=5.14.0 PyQtWebEngine~=5.14.0 pyqtgraph>=0.11a0"
+            test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0 pyqtgraph>=0.11a0"
 
           - os: windows-2019
             python-version: "3.10"

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -19,7 +19,7 @@ jobs:
           # Linux
           - os: ubuntu-20.04
             python-version: 3.7
-            test-env: "PyQt5~=5.9.2"
+            test-env: "PyQt5~=5.9.2 pyqtgraph~=0.11.0"
 
           - os: ubuntu-18.04
             python-version: 3.8
@@ -66,7 +66,7 @@ jobs:
           # Windows
           - os: windows-2019
             python-version: 3.7
-            test-env: "PyQt5~=5.9.2"
+            test-env: "PyQt5~=5.9.2 pyqtgraph~=0.11.0"
 
           - os: windows-2019
             python-version: 3.8
@@ -74,15 +74,15 @@ jobs:
 
           - os: windows-2019
             python-version: 3.9
-            test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0 pyqtgraph>=0.11a0"
+            test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0"
 
           - os: windows-2019
             python-version: "3.10"
-            test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0 pyqtgraph>=0.11a0"
+            test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0"
 
           - os: windows-2019
             python-version: "3.11"
-            test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0 pyqtgraph>=0.11a0"
+            test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0"
 
           - os: windows-2019
             python-version: "3.11"

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -89,9 +89,9 @@ jobs:
             test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3 PyQt6-WebEngine~=6.2.1 PyQt6-WebEngine-Qt6~=6.2.1"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -105,7 +105,7 @@ jobs:
           sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libxcb-shape0 $PACKAGES
 
       - name: Setup Pip Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .pip-cache
           key: ${{ runner.os }}-py-${{ matrix.python-version }}-pip-${{ hashFiles('setup.*', '.github/workflows/run-tests-workflow.yml') }}


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Add Python 3.11 to test matrices

##### Description of changes

* Add Python 3.11 to test matrices
* Drop Python 3.6 from test matrices
* Update used gh actions to avoid runner deprecation warnings

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
