### PR TITLE
[FIX] SpinBox: Fix an type error due to implicit float -> int conversion

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -627,7 +627,8 @@ class SpinBoxMixin:
             exponent = 1 + min(normalizedDiff / 10, 3)
             valueOffset = int(normalizedDiff ** exponent) * stepSize
             valueOffset = math.copysign(valueOffset, diff)
-
+            # Need to preserve the value type
+            valueOffset = type(self.preDragValue)(valueOffset)
             self.setValue(self.preDragValue + valueOffset)
 
         elif event.type() == QEvent.MouseButtonRelease:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

On Python 3.10 and higher 'dragging' on a SpinBox raises an type error
```
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange-widget-base/orangewidget/gui.py", line 631, in eventFilter
    self.setValue(self.preDragValue + valueOffset)
TypeError: setValue(self, int): argument 1 has unexpected type 'float'
```
E.g. in Orange's kNN widget click the 'Number of neighbors' spin box and drag up/down.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
