### PR TITLE
Use f-strings for plural forms and other interpolation

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -2015,7 +2015,7 @@ def auto_commit(widget, master, value, label, auto_label=None, box=False,
         if checkbox_label:
             auto_label = label
         else:
-            auto_label = label.title() + " Automatically"
+            auto_label = f"{label.title()} Automatically"
     if isinstance(box, QWidget):
         b = box
         addToLayout = False

--- a/orangewidget/report/report.py
+++ b/orangewidget/report/report.py
@@ -1,6 +1,7 @@
 import itertools
 import math
 import time
+import warnings
 from collections.abc import Iterable
 from typing import Optional
 
@@ -432,6 +433,8 @@ def plural(s, number, suffix="s"):
     :type suffix: str
     :rtype: str
     """
+    warnings.warn("Plural formed by this function is difficult to translate. "
+                  "Use orangecanvas.utils.localization.pl instead.")
     return s.format(number=number, s=suffix if number % 100 != 1 else "")
 
 

--- a/orangewidget/utils/filedialogs.py
+++ b/orangewidget/utils/filedialogs.py
@@ -39,12 +39,12 @@ def fix_extension(ext, format, suggested_ext, suggested_format):
     dlg = QMessageBox(
         QMessageBox.Warning,
         "Mismatching extension",
-        "Extension '{}' does not match the chosen file format, {}.\n\n"
-        "Would you like to fix this?".format(ext, format))
+        f"Extension '{ext}' does not match the chosen file format, {format}."
+        "\n\nWould you like to fix this?")
     role = QMessageBox.AcceptRole
     change_ext = \
         suggested_ext and \
-        dlg.addButton("Change extension to " + suggested_ext, role)
+        dlg.addButton(f"Change extension to {suggested_ext}", role)
     change_format =\
         suggested_format and \
         dlg.addButton("Save as " + suggested_format, role)

--- a/orangewidget/utils/messagewidget.py
+++ b/orangewidget/utils/messagewidget.py
@@ -18,6 +18,8 @@ from AnyQt.QtWidgets import (
 )
 from AnyQt.QtCore import pyqtSignal as Signal
 
+from orangecanvas.utils.localization import pl
+
 from orangewidget.utils.buttons import flat_button_hover_background
 
 __all__ = ["Message", "MessagesWidget"]
@@ -273,19 +275,16 @@ def summarize(messages):
     elif warnings:
         severity = Severity.Warning
 
-    def format_plural(fstr, items, *args, **kwargs):
-        return fstr.format(len(items), *args,
-                           s="s" if len(items) != 1 else "",
-                           **kwargs)
+    nerrors, nwarnings, ninfo = len(errors), len(warnings), len(info)
     if errors:
-        text_parts.append(format_plural("{} error{s}", errors))
+        text_parts.append(f"{nerrors} {pl(nerrors, 'error')}")
     if warnings:
-        text_parts.append(format_plural("{} warning{s}", warnings))
+        text_parts.append(f"{nwarnings} {pl(nwarnings, 'warning')}")
     if info:
         if not (errors and warnings and lead):
-            text_parts.append(format_plural("{} message{s}", info))
+            text_parts.append(f"{ninfo} {pl(ninfo, 'message')}")
         else:
-            text_parts.append(format_plural("{} other", info))
+            text_parts.append(f"{ninfo} other {pl(ninfo, 'message')}")
 
     if leading_text:
         text = leading_text

--- a/orangewidget/workflow/mainwindow.py
+++ b/orangewidget/workflow/mainwindow.py
@@ -154,11 +154,9 @@ class OWCanvasMainWindow(CanvasMainWindow):
         mb = QMessageBox(
             self,
             windowTitle="Clear settings",
-            text="{} needs to be restarted for the changes to take effect."
-                 .format(name),
+            text=f"{name} needs to be restarted for the changes to take effect.",
             icon=QMessageBox.Information,
-            informativeText="Press OK to restart {} now."
-                            .format(name),
+            informativeText=f"Press OK to restart {name} now.",
             standardButtons=QMessageBox.Ok | QMessageBox.Cancel,
         )
         res = mb.exec()
@@ -184,8 +182,7 @@ class OWCanvasMainWindow(CanvasMainWindow):
                     QApplication.setQuitOnLastWindowClosed(quit_temp_val)
                     QMessageBox(
                         text="Restart Cancelled",
-                        informativeText="Settings will be reset on {}'s next restart"
-                                        .format(name),
+                        informativeText=f"Settings will be reset on {name}'s next restart",
                         icon=QMessageBox.Information
                     ).exec()
                 else:

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ INSTALL_REQUIRES = [
     "pyqtgraph",
     "AnyQt>=0.1.0",
     "typing_extensions>=3.7.4.3",
-    "orange-canvas-core>=0.1.27,<0.2a",
+    "orange-canvas-core>=0.1.29,<0.2a",
     'appnope; sys_platform=="darwin"'
 ]
 


### PR DESCRIPTION
##### Issue

Some strings are composed in a way that may pose problems for translation:
- strings formed using `format` with multiple (unlabeled) `{}`
- or with a single `{}` because translation may not require (or easily accommodate) the value inserted by `{}`.
- strings formed by concatenation of partial messages
- plurals were formed by adding an -s.

##### Description of changes

- Replace problematic `str.format`'s with f-strings
- Add a better function for plural forms, and use it

##### Includes
- [X] Code changes
- [X] Tests
