### PR TITLE
ListViewFilter: Add methods source_model

### DIFF
--- a/orangewidget/utils/listview.py
+++ b/orangewidget/utils/listview.py
@@ -51,6 +51,9 @@ class ListViewFilter(QListView):
     def set_source_model(self, model: QAbstractItemModel):
         self.model().setSourceModel(model)
 
+    def source_model(self):
+        return self.model().sourceModel()
+
     def updateGeometries(self):
         super().updateGeometries()
         self.__layout()

--- a/orangewidget/utils/tests/test_listview.py
+++ b/orangewidget/utils/tests/test_listview.py
@@ -124,6 +124,7 @@ class TestListViewFilter(GuiTest):
         view = ListViewFilter()
         view.set_source_model(model)
         self.assertIs(view.model().sourceModel(), model)
+        self.assertIs(view.source_model(), model)
 
     def test_set_proxy(self):
         proxy = QSortFilterProxyModel()


### PR DESCRIPTION
##### Issue

`ListViewFilter` has a setter method `set_source_model`. A getter `source_model` would be convenient, so we wouldn't have to call `model().sourceModel()`.

##### Description of changes

Here it is.

##### Includes
- [X] Code changes
- [X] Tests