### PR TITLE
BaseWidget: Allow keywords as strings

### DIFF
--- a/orangewidget/tests/test_widget.py
+++ b/orangewidget/tests/test_widget.py
@@ -67,6 +67,27 @@ class WidgetTestCase(WidgetTest):
         with self.assertRaises(AttributeError):
             setattr(widget, 'unknown_field2.field', 6)
 
+    def test_keywords(self):
+        class Widget(OWBaseWidget):
+            pass
+
+        self.assertEqual(Widget.keywords, [])
+
+        class Widget(OWBaseWidget):
+            keywords = ["bar", "qux"]
+
+        self.assertEqual(Widget.keywords, ["bar", "qux"])
+
+        class Widget(OWBaseWidget):
+            keywords = "foo bar   baz"
+
+        self.assertEqual(Widget.keywords, ["foo", "bar", "baz"])
+
+        class Widget(OWBaseWidget):
+            keywords = "foo bar, baz"
+
+        self.assertEqual(Widget.keywords, ["foo bar", "baz"])
+
     def test_notify_controller_on_attribute_change(self):
         widget = self.create_widget(MyWidget)
 

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -112,6 +112,11 @@ class WidgetMetaClass(type(QDialog)):
     def __new__(mcs, name, bases, namespace, openclass=False, **kwargs):
         cls = super().__new__(mcs, name, bases, namespace, **kwargs)
         cls.convert_signals()
+        if isinstance(cls.keywords, str):
+            if "," in cls.keywords:
+                cls.keywords = [kw.strip() for kw in cls.keywords.split(",")]
+            else:
+                cls.keywords = cls.keywords.split()
         if not cls.name: # not a widget
             return cls
         cls.settingsHandler = \
@@ -240,7 +245,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     settingsHandler: SettingsHandler = None
 
     #: Widget keywords, used for finding it in the quick menu.
-    keywords: List[str] = []
+    keywords: Union[str, List[str]] = []
 
     #: Widget priority, used for sorting within a category.
     priority: int = sys.maxsize


### PR DESCRIPTION
##### Issue

When translating widget, e.g. to Slovenian, one can translate keywords (literally, or replace the by other words), but can't increase their number. This would be desirable because some languages may have more applicable keywords, and also because we often want to keep the original, English keywords.

##### Description of changes

Keywords can now also be given as a string (separated with commas or just spaces). Meta class converts them to strings.

This assumes that keywords are always single words. I believe this to be harmless; if somebody uses a keyword "classification tree", this will simply match both, "classification" and "tree".

##### Includes
- [X] Code changes
- [X] Tests
