### PR TITLE
Report: improve report_table

### DIFF
--- a/orangewidget/report/tests/test_report.py
+++ b/orangewidget/report/tests/test_report.py
@@ -47,31 +47,19 @@ class TestReport(GuiTest):
         self.maxDiff = None
         self.assertEqual(
             rep.report_html,
-            '<h2>Name</h2><table>\n'
-            '<tr>'
-            '<th style="color:black;border:0;background:transparent;'
-            'text-align:left;vertical-align:middle;">a</th>'
-            '<th style="color:black;border:0;background:transparent;'
-            'text-align:left;vertical-align:middle;">b</th>'
-            '<th style="color:black;border:0;background:transparent;'
-            'text-align:left;vertical-align:middle;">c</th>'
-            '</tr>'
-            '<tr>'
-            '<td style="color:black;border:0;background:transparent;'
-            'text-align:center;vertical-align:top;">x</td>'
-            '<td style="color:black;border:0;background:transparent;'
-            'text-align:right;vertical-align:middle;">1</td>'
-            '<td style="color:black;border:0;background:transparent;'
-            'text-align:right;vertical-align:middle;">2</td>'
-            '</tr>'
-            '<tr>'
-            '<td style="color:black;border:0;background:transparent;'
-            'font-weight: bold;text-align:left;vertical-align:middle;">y</td>'
-            '<td style="color:black;border:0;background:transparent;'
-            'text-align:right;vertical-align:middle;">2</td>'
-            '<td style="color:black;border:0;background:#ff0000;'
-            'text-align:right;vertical-align:middle;">2</td>'
-            '</tr></table>')
+            """
+<h2>Name</h2><table>
+<tr><th style="color:black; background:transparent; text-align:left; vertical-align:middle;">a</th>
+<th style="color:black; background:transparent; text-align:left; vertical-align:middle;">b</th>
+<th style="color:black; background:transparent; text-align:left; vertical-align:middle;">c</th>
+</tr><tr><td style="color:black; background:transparent; text-align:center; vertical-align:top;">x</td>
+<td style="color:black; background:transparent; text-align:right; vertical-align:middle;">1</td>
+<td style="color:black; background:transparent; text-align:right; vertical-align:middle;">2</td>
+</tr><tr><td style="color:black; background:transparent; font-weight: bold; text-align:left; vertical-align:middle;">y</td>
+<td style="color:black; background:transparent; text-align:right; vertical-align:middle;">2</td>
+<td style="color:black; background:#ff0000; text-align:right; vertical-align:middle;">2</td>
+</tr></table>
+            """.strip())
 
     def test_save_report_permission(self):
         """
@@ -170,31 +158,8 @@ class TestReport(GuiTest):
         view.show()
         view.setModel(model)
         rep.report_table('Name', view)
-        self.maxDiff = None
-        pattern = re.compile(
-            re.escape(
-                '<h2>Name</h2><table>\n'
-                '<tr>'
-                '<th style="color:black;border:0;background:transparent;'
-                'text-align:left;vertical-align:middle;">a</th>'
-                '<th style="color:black;border:0;background:transparent;'
-                'text-align:left;vertical-align:middle;">b</th>'
-                '<th style="color:black;border:0;background:transparent;'
-                'text-align:left;vertical-align:middle;">c</th>'
-                '</tr>'
-                '<tr>'
-                '<td style="color:black;border:0;background:transparent;'
-                'text-align:left;vertical-align:middle;">x</td>'
-                '<td style="color:black;border:0;background:transparent;'
-                'text-align:right;vertical-align:middle;">'
-                '<img src="data:image/png;base64,'
-            ) + '(.+)' + re.escape(  # any string for the icon
-                '"/>1</td>'
-                '<td style="color:black;border:0;background:transparent;'
-                'text-align:right;vertical-align:middle;">'
-            ) + '(.+)' + re.escape('</td></tr></table>')  # str for the scene
-        )
-        self.assertTrue(bool(pattern.match(rep.report_html)))
+        self.assertIsNotNone(
+            re.search('<img(.*) src="data:image/png;base64,', rep.report_html))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue

Fixes https://github.com/biolab/orange3/issues/6209.

<img width="401" alt="Screenshot 2023-01-20 at 21 22 47" src="https://user-images.githubusercontent.com/2387315/213800027-831cfb1d-d2ef-4d38-80e9-9220d25d1777.png">

##### Description of changes

- Removes border around selected cells.
- For selected cells, it ignores colors by model and uses highlight colors from palette.
- Uses delegate's `displayText` (if it exists) to format the value
- Puts decoration in the same line (`display: inline`) and vertically centers it.
- Adds an argument `indicate_selection` that can be set to `False` in widgets that do not want to show selection in reports.

##### Includes
- [X] Code changes
