### PR TITLE
auto_commit: Disable button on clean, enable on dirty

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -1972,7 +1972,7 @@ def auto_commit(widget, master, value, label, auto_label=None, box=False,
                 do_commit()
         else:
             btn.setText(label)
-            btn.setEnabled(True)
+            btn.setEnabled(is_dirty())
         if callback:
             callback()
 
@@ -1982,6 +1982,7 @@ def auto_commit(widget, master, value, label, auto_label=None, box=False,
 
         def set_dirty(state):
             commit.dirty = state
+            btn.setEnabled(state)
     else:
         dirty = False
 
@@ -1991,6 +1992,7 @@ def auto_commit(widget, master, value, label, auto_label=None, box=False,
         def set_dirty(state):
             nonlocal dirty
             dirty = state
+            btn.setEnabled(state)
 
     def conditional_commit():
         if getattr(master, value):
@@ -2008,8 +2010,6 @@ def auto_commit(widget, master, value, label, auto_label=None, box=False,
             set_dirty(False)
         finally:
             QApplication.restoreOverrideCursor()
-
-    set_dirty(False)
 
     if not auto_label:
         if checkbox_label:
@@ -2052,7 +2052,6 @@ def auto_commit(widget, master, value, label, auto_label=None, box=False,
 
     if not checkbox_label:
         btn.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
-    checkbox_toggled()
 
     if decorated:
         commit.now = do_commit
@@ -2076,6 +2075,8 @@ def auto_commit(widget, master, value, label, auto_label=None, box=False,
         # and remove `if` that follows?
         setattr(master, 'unconditional_' + commit_name, commit)
         setattr(master, commit_name, conditional_commit)
+
+    checkbox_toggled()
 
     misc['addToLayout'] = addToLayout
     miscellanea(b, widget, widget, **misc)

--- a/orangewidget/tests/test_gui.py
+++ b/orangewidget/tests/test_gui.py
@@ -250,32 +250,57 @@ class TestDeferred(WidgetTest):
             apply = gui.deferred(real_apply)
 
         w = self.create_widget(Widget)
+        self.assertFalse(w.commit_button.button.isEnabled())
 
         # clicked, but no autocommit
         w.checkbox.click()
         w.real_apply.assert_not_called()
+        self.assertTrue(w.commit_button.button.isEnabled())
 
         # manual commit
         w.commit_button.button.click()
+        self.assertFalse(w.commit_button.button.isEnabled())
         w.real_apply.assert_called()
         w.real_apply.reset_mock()
 
         # enable auto commit - this should not trigger commit
         w.commit_button.checkbox.click()
+        self.assertFalse(w.commit_button.button.isEnabled())
         w.real_apply.assert_not_called()
 
         # clicking control should auto commit
         w.checkbox.click()
+        self.assertFalse(w.commit_button.button.isEnabled())
         w.real_apply.assert_called()
         w.real_apply.reset_mock()
 
-        # disabling and reenable auto commit without chenging the control
+        # disabling and reenable auto commit without changing the control
         # should not trigger commit
-        w.commit_button.checkbox.click()
+        w.commit_button.checkbox.click()  # now disabled
+        self.assertFalse(w.commit_button.button.isEnabled())
         w.real_apply.assert_not_called()
+
+        w.commit_button.checkbox.click()  # now enabled again
+        self.assertFalse(w.commit_button.button.isEnabled())
+        w.real_apply.assert_not_called()
+
+        # enabling auto-commit at dirty state should auto-commit and disable the button
+        w.commit_button.checkbox.click()  # now disabled
+        w.checkbox.click()  # State is dirty
+        w.real_apply.assert_not_called()  # ... but commit is not called
+        self.assertTrue(w.commit_button.button.isEnabled())  # ... so button is enabled.
+        w.commit_button.checkbox.click()  # Enabling auto commit
+        w.real_apply.assert_called()  # ... calls commit
+        self.assertFalse(w.commit_button.button.isEnabled())  # ... and disables the button
+        w.real_apply.reset_mock()
+        w.commit_button.checkbox.click()  # Disabling auto commit
+        self.assertFalse(w.commit_button.button.isEnabled())  # ... keeps the button disabled
+        w.commit_button.checkbox.click()  # Enabling auto commit ...
+        self.assertFalse(w.commit_button.button.isEnabled())  # ... keeps the button disabled
 
         # calling now should always call the apply
         w.apply.now()
+        self.assertFalse(w.commit_button.button.isEnabled())
         w.real_apply.assert_called_with(w)
         w.real_apply.reset_mock()
 


### PR DESCRIPTION
##### Issue

Ref: #226.

##### Description of changes

#210 allows for changing push buttons, but with @BlazZupan and @markotoplak we couldn't agree on clear, yet aesthetically pleasing way to indicate a dirty state. I initially didn't like their alternative idea of indicating dirty/clean state by enabling/disabling the button, but now that I tried it I find it simple and clean.

I think we should keep the code from #210 (just modified to a more general form) for potential use elsewhere.

##### Includes
- [X] Code changes
- [X] Tests
