### PR TITLE
Use signal's class-attribute name as default id

### DIFF
--- a/orangewidget/utils/tests/test_widgetpreview.py
+++ b/orangewidget/utils/tests/test_widgetpreview.py
@@ -49,8 +49,8 @@ class TestWidgetPreviewBase(WidgetTest):
                 input_int = MockInput("int1", int)
                 input_float1 = MockInput("float1", float, default=True)
                 input_float2 = MockInput("float2", float)
-                input_str1 = MockInput("float1", str)
-                input_str2 = MockInput("float2", str)
+                input_str1 = MockInput("str1", str)
+                input_str2 = MockInput("str2", str)
 
             int1 = Inputs.input_int(MagicMock())
             float1 = Inputs.input_float1(MagicMock())

--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -111,9 +111,9 @@ class WidgetMetaClass(type(QDialog)):
     # pylint: disable=bad-classmethod-argument
     def __new__(mcs, name, bases, namespace, openclass=False, **kwargs):
         cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        cls.convert_signals()
         if not cls.name: # not a widget
             return cls
-        cls.convert_signals()
         cls.settingsHandler = \
             SettingsHandler.create(cls, template=cls.settingsHandler)
         return cls


### PR DESCRIPTION
##### Issue

This is needed for https://github.com/biolab/orange-canvas-core/pull/257 to have an effect, but can be merged independently.

##### Description of changes

Most signals do not have ids, but if they are defined in a class, the name of the attribute that they are assigned to can be used as default id.

This PR also checks that id's and names are unique (which should had already been an error), and warn if the same name and id do not refer to different signals (which is required for backward compatibility of https://github.com/biolab/orange-canvas-core/pull/257).

##### Includes
- [X] Code changes
- [X] Tests