### PR TITLE
IndicatorItemDelegate: Show hollow indicators

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -2581,19 +2581,27 @@ class IndicatorItemDelegate(QtWidgets.QStyledItemDelegate):
         super().paint(painter, option, index)
         rect = option.rect
         indicator = index.data(self.role)
+        # We exit on `indicator is None`, essentially. But for backward compat,
+        # we also exit on other falsy values, except False, which now indicates
+        # an empty indicator.
+        if not indicator and indicator is not False:
+            return
 
-        if indicator:
+        color_for_state = text_color_for_state(option.palette, option.state)
+        pen = QtGui.QPen(color_for_state, 1)
+        if indicator is False:
+            brush = Qt.NoBrush
+        else:
             brush = index.data(Qt.ForegroundRole)
             if brush is None:
-                brush = QtGui.QBrush(
-                    text_color_for_state(option.palette, option.state))
-            painter.save()
-            painter.setRenderHints(QtGui.QPainter.Antialiasing)
-            painter.setBrush(brush)
-            painter.setPen(QtGui.QPen(brush, 1))
-            painter.drawEllipse(rect.center(),
-                                self.indicatorSize, self.indicatorSize)
-            painter.restore()
+                brush = QtGui.QBrush(color_for_state)
+        painter.save()
+        painter.setRenderHints(QtGui.QPainter.Antialiasing)
+        painter.setBrush(brush)
+        painter.setPen(pen)
+        painter.drawEllipse(rect.center(),
+                            self.indicatorSize, self.indicatorSize)
+        painter.restore()
 
 
 class LinkStyledItemDelegate(QStyledItemDelegate):


### PR DESCRIPTION
##### Issue

Different-colored indicators may be difficult to distinguish. 

##### Description of changes

This PR adds another visual cue besides color: indicator can be hollow or filled.

Backward compatibility with existing widget should work, I guess. IMHO, indicators are used only the Datasets widget, which is adapted accordingly, so this is not much of concern.

##### Includes
- [X] Code changes
