### PR TITLE
[FIX] itemmodels: Ensure stable descending sort

### DIFF
--- a/orangewidget/utils/itemmodels.py
+++ b/orangewidget/utils/itemmodels.py
@@ -163,12 +163,16 @@ class AbstractSortTableModel(QAbstractTableModel):
         Return indices of sorted data. May be reimplemented to handle
         sorting in a certain way, e.g. to sort NaN values last.
         """
+        if order == Qt.DescendingOrder:
+            # to ensure stable descending order, sort reversed data ...
+            data = data[::-1]
         if data.ndim == 1:
             indices = numpy.argsort(data, kind="mergesort")
         else:
             indices = numpy.lexsort(data.T[::-1])
         if order == Qt.DescendingOrder:
-            indices = indices[::-1]
+            # ... and reverse (as well as invert) resulting indices
+            indices = len(data) - 1 - indices[::-1]
         return indices
 
     def sort(self, column: int, order: Qt.SortOrder = Qt.AscendingOrder):

--- a/orangewidget/utils/tests/test_itemmodels.py
+++ b/orangewidget/utils/tests/test_itemmodels.py
@@ -254,6 +254,20 @@ class TestAbstractSortTableModel(unittest.TestCase):
         self.assertSequenceEqual(model.mapToSourceRows(...).tolist(), [0, 2, 1])
         self.assertSequenceEqual(model.mapFromSourceRows(...).tolist(), [0, 2, 1])
 
+    def test_stable_descending_sort(self):
+        def assert_indices_equal(indices):
+            self.assertSequenceEqual(model.mapToSourceRows(...).tolist(),
+                                     indices)
+        model = PyTableModel([[1, 4],
+                              [2, 2],
+                              [2, 3],
+                              [2, 2],
+                              [3, 3]])
+        model.sort(0, Qt.DescendingOrder)
+        assert_indices_equal([4, 1, 2, 3, 0])
+        model.sort(1, Qt.DescendingOrder)
+        assert_indices_equal([0, 4, 2, 1, 3])
+
     def test_sorting_fallback(self):
         class TableModel(PyTableModel):
             def sortColumnData(self, column):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

`AbstractSortTableModel._argsortData` does not perform a stable descending sort.
It essentially does `reversed(argsort(data))` which is not stable. 

##### Description of changes

* Ensure stable descending sort (argsort on reversed data then reverse and invert the resulting indices).
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
