### PR TITLE
[FIX] widget: Fix PyQt6 compatibility in __showStatusBarMenu

### DIFF
--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -1310,7 +1310,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             b.mapToGlobal(QPoint(0, 0)), b.size()
         )
         menu.ensurePolished()
-        screen_rect = QApplication.desktop().availableGeometry(b)
+        screen_rect = b.screen().availableGeometry()
         menu_rect = dropdown_popup_geometry(
             menu.sizeHint(), popup_rect, screen_rect, preferred_direction="up"
         )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

On platforms without a native menu bar pressing the hamburger menu button causes an error when using PyQt6.

```
-------------------------- AttributeError Exception ---------------------------
Traceback (most recent call last):
  File "/home/ales/devel/orange-widget-base/orangewidget/widget.py", line 1313, in __showStatusBarMenu
    screen_rect = QApplication.desktop().availableGeometry(b)
                  ^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'QApplication' has no attribute 'desktop'
-------------------------------------------------------------------------------
```
##### Description of changes

Replace use of `QApplication.desktop`. Add a test that covers the code in question.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
