### PR TITLE
TestGui: Add decorators for enabling tests depending upon language

### DIFF
--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -159,6 +159,7 @@ class GuiTest(unittest.TestCase):
     GuiTest ensures that a QApplication exists before tests are run an
     """
     tear_down_stack: ExitStack
+    LANGUAGE = "English"
 
     @classmethod
     def setUpClass(cls):
@@ -205,8 +206,21 @@ class GuiTest(unittest.TestCase):
         super().tearDown()
         QTest.qWait(0)
 
+    @classmethod
+    def skipNonEnglish(cls, f):
+        return cls.runOnLanguage("English")(f)
+
+    @classmethod
+    def runOnLanguage(cls, lang):
+        def decorator(f):
+            if cls.LANGUAGE != lang:
+                f = unittest.skip(f"Test is valid only for {lang} release")(f)
+            return f
+        return decorator
+
 
 NO_VALUE = object()
+
 
 class WidgetTest(GuiTest):
     """Base class for widget tests
@@ -220,7 +234,6 @@ class WidgetTest(GuiTest):
     widgets = []  # type: List[OWBaseWidget]
 
     def __init_subclass__(cls, **kwargs):
-
         def test_minimum_size(self):
             widget = getattr(self, "widget", None)
             if widget is None:

--- a/orangewidget/tests/test_test_base.py
+++ b/orangewidget/tests/test_test_base.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from orangewidget.tests.base import GuiTest
+
+
+class SkipTest(Exception):
+    pass
+
+
+class TestGuiTest(unittest.TestCase):
+    @patch("unittest.case.SkipTest", SkipTest)
+    def test_english(self):
+        class TestA(GuiTest):
+            pure_test = Mock()
+            test = GuiTest.skipNonEnglish(pure_test)
+
+            pure_test_si = Mock()
+            test_si = GuiTest.runOnLanguage("Slovenian")(pure_test_si)
+
+        test_obj = TestA()
+
+        test_obj.test()
+        test_obj.pure_test.assert_called()
+
+        self.assertRaises(SkipTest, test_obj.test_si)
+        test_obj.pure_test_si.assert_not_called()
+
+    @patch("unittest.case.SkipTest", SkipTest)
+    @patch("orangewidget.tests.base.GuiTest.LANGUAGE", "Slovenian")
+    def test_non_english(self):
+        class TestA(GuiTest):
+            pure_test = Mock()
+            test = GuiTest.skipNonEnglish(pure_test)
+
+            pure_test_si = Mock()
+            test_si = GuiTest.runOnLanguage("Slovenian")(pure_test_si)
+
+            pure_test_fr = Mock()
+            test_fr = GuiTest.runOnLanguage("French")(pure_test_fr)
+
+        test_obj = TestA()
+
+        self.assertRaises(SkipTest, test_obj.test)
+        test_obj.pure_test.assert_not_called()
+
+        test_obj.test_si()
+        test_obj.pure_test_si.assert_called()
+
+        self.assertRaises(SkipTest, test_obj.test_fr)
+        test_obj.pure_test_fr.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

We do not run tests on Slovenian version of Orange because they fail on language-dependent strings. Some tests can be made language independent, while some not (at least not easily).

##### Description of changes

- Add decorator `GuiTest.skipNonEnglish`, which skips a test if `GuiTest.LANGUAGE` is not "English".
- Also add decorator `GuitTest.runForLanguage(lang)` which allows specifying a language on which the test should be run.

The former is of course a shortcut for the latter.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
