### PR TITLE
[FIX] Fix PyQt6 warnings

### DIFF
--- a/orangewidget/utils/concurrent.py
+++ b/orangewidget/utils/concurrent.py
@@ -165,7 +165,7 @@ class FutureWatcher(QObject, PyOwned):
     exceptionReady = Signal(BaseException)
 
     # A private event type used to notify the watcher of a Future's completion
-    __FutureDone = QEvent.registerEventType()
+    __FutureDone = QEvent.Type(QEvent.registerEventType())
 
     def __init__(self, future=None, parent=None, **kwargs):
         super().__init__(parent, **kwargs)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Deprecation warnings when running with PyQt6 e.g.
```
rangewidget/utils/tests/test_concurrent.py::TestFutureWatcher::test_watcher
  /home/ales/devel/orange-widget-base/orangewidget/utils/concurrent.py:202: DeprecationWarning: QEvent constructor is deprecated
    selfref, QEvent(FutureWatcher.__FutureDone))
```
##### Description of changes

Change type of event type constants.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
