### PR TITLE
File dialog: Add as much path as necessary to make names unambiguous

### DIFF
--- a/orangewidget/utils/tests/test_filedialogs.py
+++ b/orangewidget/utils/tests/test_filedialogs.py
@@ -1,9 +1,104 @@
+import sys
+
 import os
 import unittest
 from unittest.mock import Mock
 from tempfile import NamedTemporaryFile
 
-from orangewidget.utils.filedialogs import RecentPath, open_filename_dialog
+from orangewidget.utils.filedialogs import RecentPath, open_filename_dialog, \
+    unambiguous_paths
+
+
+class TestUtils(unittest.TestCase):
+    def test_unambiguous_paths(self):
+        paths = [
+            "asd.txt",
+            "abc/def/ghi.txt",
+            "abc/def/jkl.txt",
+            "abc/xyz/jkl.txt",
+            "abc/xyz/rty/qwe.txt",
+            "abd/xyz/rty/qwe.txt",
+            "abe/xyz/rty/qwe.txt",
+        ]
+
+        paths = [t.replace("/", os.path.sep, 1) for t in paths]
+
+        def test(exp, **kwargs):
+            self.assertEqual(unambiguous_paths(paths, **kwargs),
+                             [t.replace("/", os.path.sep) for t in exp])
+
+        test(["asd.txt",
+              "ghi.txt",
+              "def/jkl.txt",
+              "xyz/jkl.txt",
+              "abc/xyz/rty/qwe.txt",
+              "abd/xyz/rty/qwe.txt",
+              "abe/xyz/rty/qwe.txt"])
+
+        test(["asd.txt",
+              "def/ghi.txt",
+              "def/jkl.txt",
+              "xyz/jkl.txt",
+              "abc/xyz/rty/qwe.txt",
+              "abd/xyz/rty/qwe.txt",
+              "abe/xyz/rty/qwe.txt"], minlevel=2)
+
+        test(["asd.txt",
+              "abc/def/ghi.txt",
+              "abc/def/jkl.txt",
+              "abc/xyz/jkl.txt",
+              "abc/xyz/rty/qwe.txt",
+              "abd/xyz/rty/qwe.txt",
+              "abe/xyz/rty/qwe.txt"], minlevel=3)
+
+        test(["asd.txt",
+              "abc/def/ghi.txt",
+              "abc/def/jkl.txt",
+              "abc/xyz/jkl.txt",
+              "abc/xyz/rty/qwe.txt",
+              "abd/xyz/rty/qwe.txt",
+              "abe/xyz/rty/qwe.txt"], minlevel=4)
+
+        # For simplicity, omit this test on Windows; if it works on Posix paths,
+        # it works on Windows, too.
+        if os.path.sep == "/":
+            t = ["abc/def/ghi.txt", "abc/def/ghi.txt"]
+            self.assertEqual(unambiguous_paths(t), t)
+
+    if sys.platform == "win32":
+        ptch1 = ptch2 = ptch3 = lambda x: x
+    else:
+        # This test is intended for Windows, but for easier testing of a test
+        # on non-Windows machine, we patch it to make it work on others
+        ptch1 = unittest.mock.patch("os.path.sep", "/")
+        ptch2 = unittest.mock.patch("os.path.altsep", "\\")
+        ptch3 = unittest.mock.patch(
+            "os.path.join",
+            lambda *args, oj=os.path.join: oj(*args).replace("/", "\\"))
+    @ptch1
+    @ptch2
+    @ptch3
+    def test_unambiguous_paths_windows(self):
+        paths = ["C:\\Documents/Newsletters\\Summer2018.pdf",
+                 "D:\\Documents/Newsletters\\Summer2018.pdf"]
+        self.assertEqual(unambiguous_paths(paths),
+                         ["C:\\Documents\\Newsletters\\Summer2018.pdf",
+                          "D:\\Documents\\Newsletters\\Summer2018.pdf"]
+                         )
+
+        paths = ["C:\\abc\\def\\Summer2018.pdf",
+                 "C:\\abc\\deg\\Summer2018.pdf"]
+        self.assertEqual(unambiguous_paths(paths),
+                         ["def\\Summer2018.pdf",
+                          "deg\\Summer2018.pdf", ]
+                         )
+
+        paths = ["C:\\deg\\Summer2018.pdf",
+                 "D:\\deg\\Summer2018.pdf"]
+        self.assertEqual(unambiguous_paths(paths),
+                         ["C:\\deg\\Summer2018.pdf",
+                          "D:\\deg\\Summer2018.pdf", ]
+                         )
 
 
 class TestRecentPath(unittest.TestCase):


### PR DESCRIPTION
##### Issue

Fixes https://github.com/biolab/orange3/issues/6453.

##### Description of changes

In file dialog combos, keep as much directories as necessary to disambiguate between the paths.

The code also allows for keeping more, for instance always keeping the last directory. In case we decide we prefer it.

##### Includes
- [X] Code changes
- [X] Tests
