### PR TITLE
MessageGroup.clear: Add argument owner

### DIFF
--- a/orangewidget/utils/tests/test_messages.py
+++ b/orangewidget/utils/tests/test_messages.py
@@ -1,0 +1,40 @@
+import unittest
+
+from orangewidget.tests.base import WidgetTest
+from orangewidget.widget import OWBaseWidget, Msg
+
+
+class TestMessages(WidgetTest):
+    def test_clear_owner(self):
+        class WidgetA(OWBaseWidget, openclass=True):
+            class Error(OWBaseWidget.Error):
+                err_a = Msg("error a")
+
+        class WidgetB(WidgetA):
+            class Error(WidgetA.Error):
+                err_b = Msg("error b")
+
+        w = self.create_widget(WidgetB)
+        w.Error.err_a()
+        w.Error.err_b()
+        self.assertTrue(w.Error.err_a.is_shown())
+        self.assertTrue(w.Error.err_b.is_shown())
+        w.Error.clear()
+        self.assertFalse(w.Error.err_a.is_shown())
+        self.assertFalse(w.Error.err_b.is_shown())
+
+        w.Error.err_a()
+        w.Error.err_b()
+        w.Error.clear(owner=WidgetB)
+        self.assertTrue(w.Error.err_a.is_shown())
+        self.assertFalse(w.Error.err_b.is_shown())
+
+        w.Error.err_a()
+        w.Error.err_b()
+        w.Error.clear(owner=WidgetA)
+        self.assertFalse(w.Error.err_a.is_shown())
+        self.assertTrue(w.Error.err_b.is_shown())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

`Error.clear()` clears messages up and down in the hierarchy of widgets, which makes it safe only for flat classes. Base classes mustn't use it to avoid clearing subclass messages, and derived classes shouldn't use it even if base classes have no messages because they may be added in the future. If one wants to be cautious, he must clear each message separately, which is annoying if there are too many.

##### Description of changes

`MessageGroup.clear` now accepts an argument `owner: Type[OWBaseWidget]`, and only deletes messages defined within the given class. E.g.`self.Error.clear(owner=OWNxFile)` would clear messages defined in `OWNxFile` but not those from its base classes or subclasses.

@ales-erjavec, searching for the class that defines a message group must be done during binding, and requires searching for groups in widget's mro. Feel free to reject the PR if you find this too ugly.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
