### PR TITLE
[MNT] ci: Update ubuntu image for PyQt6 6.5 tests

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -42,10 +42,10 @@ jobs:
             test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3 PyQt6-WebEngine~=6.2.1 PyQt6-WebEngine-Qt6~=6.2.1"
             extra-system-packages: "libegl1-mesa"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: "3.11"
             test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0 PyQt6-WebEngine~=6.5.0 PyQt6-WebEngine-Qt6~=6.5.0"
-            extra-system-packages: "libegl1-mesa libxcb-cursor0"
+            extra-system-packages: "libegl1-mesa libxcb-cursor0 glibc-tools"
 
           # macOS
           - os: macos-11


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

PyQt6 6.5 tests fail on ubuntu-20.04 due to
https://www.riverbankcomputing.com/pipermail/pyqt/2023-June/045313.html

##### Description of changes

Use ubuntu-22.04 image

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
