### PR TITLE
[MNT] readthedocs: Remove no longer supported 'system_packages'

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,7 @@
 version: 2
 
 python:
-   version: 3.8
+   version: "3.8"
    install:
       - requirements: doc/requirements-rtd.txt
         # no - method: pip here, -e . is already in doc/requirements-rtd.txt
-
-   system_packages: true


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

RTD docs build [fails](https://readthedocs.org/projects/orange-widget-base/builds/21933713/) due to dropped [system_packages](https://blog.readthedocs.com/drop-support-system-packages/) key 


##### Description of changes
Remove `system_packages` key

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
