### PR TITLE
[FIX] itemmodels: Remove use of private signals from PyTableModel

### DIFF
--- a/orangewidget/utils/itemmodels.py
+++ b/orangewidget/utils/itemmodels.py
@@ -434,9 +434,9 @@ class PyTableModel(AbstractSortTableModel):
             # Signal changes
             parent = QModelIndex()
             if newstop > stop:
-                self.rowsAboutToBeInserted.emit(parent, stop, newstop - 1)
+                self.beginInsertRows(parent, stop, newstop - 1)
             elif newstop < stop:
-                self.rowsAboutToBeRemoved.emit(parent, newstop, stop - 1)
+                self.beginRemoveRows(parent, newstop, stop - 1)
 
             # Make changes
             self._table[i] = value
@@ -447,9 +447,9 @@ class PyTableModel(AbstractSortTableModel):
                     self.index(start, 0),
                     self.index(min(stop, newstop) - 1, self.columnCount() - 1))
             if newstop > stop:
-                self.rowsInserted.emit(parent, stop, newstop - 1)
+                self.endInsertRows()
             elif newstop < stop:
-                self.rowsRemoved.emit(parent, newstop, stop - 1)
+                self.endRemoveRows()
         else:
             self._table[i] = value
             i %= len(self)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Using PyQt6 6.5.3 (still unreleased on PyPi but available at https://www.riverbankcomputing.com/pypi/simple/)
```
Traceback (most recent call last):
  File "/home/ales/devel/orange-widget-base/orangewidget/utils/tests/test_itemmodels.py", line 164, in test_set_item_signals
    self.model[2:4] = p(6, 7, 8, 9, 10) + [[11, 2]]
    ~~~~~~~~~~^^^^^
  File "/home/ales/devel/orange-widget-base/orangewidget/utils/itemmodels.py", line 437, in __setitem__
    self.rowsAboutToBeInserted.emit(parent, stop, newstop - 1)
AttributeError: 'PyTableModel' does not have a signal with the signature rowsAboutToBeInserted(QModelIndex, int, int)
```

rowsAboutToBeRemoved/Inserted, ... are private signals of QAbstractItemModel and should not be emitted directly. Use beginInsert/RemoveRows and endInsert/RemoveRows instead.

##### Description of changes

Replace rowsAboutToBeRemoved/Inserted, ...  with  beginInsert/RemoveRows, ...

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
