### PR TITLE
[RFC] Don't call eventFilter on destroyed objects

### DIFF
--- a/orangewidget/tests/test_widget.py
+++ b/orangewidget/tests/test_widget.py
@@ -758,5 +758,36 @@ class TestWidgetMenu(WidgetTest):
         self.assertFalse(mb.isVisibleTo(w))
 
 
+class MetaClassTest(WidgetTest):
+    @patch("AnyQt.QtWidgets.QDialog.eventFilter")
+    def test_eventFilter(self, eventFilter):
+        class NoFilter(OWBaseWidget):
+            pass
+
+        class HasFilter(OWBaseWidget):
+            def __init__(self):
+                self.myprop = 42
+
+            def eventFilter(self, *args ,**kwargs):
+                super().eventFilter(*args, **kwargs)
+                self.myprop += 1  # will crash on empty dict
+
+        nf = NoFilter()
+        nf.eventFilter()
+        eventFilter.assert_called()
+        eventFilter.reset_mock()
+
+        hf = HasFilter()
+        hf.eventFilter()
+        self.assertEqual(hf.myprop, 43)
+        eventFilter.assert_called()
+        eventFilter.reset_mock()
+
+        hf.__dict__.clear()
+        hf.eventFilter()
+        eventFilter.assert_called()
+        eventFilter.reset_mock()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue

An alternative to https://github.com/biolab/orange3/pull/6596.

Qt may call `eventFilter` for objects that have already been destroyed and have an empty `__dict__`. This may cause crashes, in particular in unit tests.

##### Description of changes

This PR resolves some of those cases by wrapping `eventFilter` into a method that redirects such calls directly to the `eventFilter` inherited from `QDialog`. Note that this only works for classes derived from `OWWidget`. Most `eventFilter` methods that we use in Orange are defined in other classes.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
