### PR TITLE
[MNT] readthedocs: Add build.os key

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 python:
-   version: "3.8"
    install:
       - requirements: doc/requirements-rtd.txt
         # no - method: pip here, -e . is already in doc/requirements-rtd.txt


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->


RTD docs build [fails](https://readthedocs.org/projects/orange-widget-base/builds/22268358/) due to missing [build.os key](https://blog.readthedocs.com/use-build-os-config/) 



##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
