### PR TITLE
[MNT] CI: Constrain PyQt6-Qt6 version in tests

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -63,7 +63,7 @@ jobs:
 
           - os: macos-12
             python-version: "3.11"
-            test-env: "PyQt6~=6.2.3 PyQt6-WebEngine~=6.2.1"
+            test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3 PyQt6-WebEngine~=6.2.1 PyQt6-WebEngine-Qt6~=6.2.1"
 
           - os: macos-12
             python-version: "3.11"


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

macos test with PyQt6 6.2 does not constrain PyQt6-Qt6 version causing test failure because it runs with PyQt6-Qt6 6.6.*
https://github.com/biolab/orange-widget-base/actions/runs/7139760619/job/19443786304?pr=260

##### Description of changes

Constrain the PyQt6-Qt6 anf PyQt6-WebEngine-Qt6 versions.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
