### PR TITLE
[FIX] setup.py: Replace use of imp module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,8 +119,12 @@ if not release:
         GIT_REVISION = git_version()
     elif os.path.exists(filename):
         # must be a source distribution, use existing version file
-        import imp
-        version = imp.load_source("orangewidget.version", filename)
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "orangewidget.version", filename
+        )
+        version = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(version)
         GIT_REVISION = version.git_revision
     else:
         GIT_REVISION = "Unknown"


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

`imp` module was deprecated and removed in Python 3.12. This means that installing from a sdist package fails on Python 3.12+.

##### Description of changes

Replace use of imp module

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
