### PR TITLE
[FIX] gui.spinBox: Remove extraneous created widget box

### DIFF
--- a/orangewidget/gui.py
+++ b/orangewidget/gui.py
@@ -773,7 +773,7 @@ def spin(widget, master, value, minv, maxv, step=1, box=None, label=None,
     else:
         b = widget
         hasHBox = False
-    if not hasHBox and (checked or callback or posttext):
+    if not hasHBox and (checked or posttext):
         bi = hBox(b, addToLayout=False)
     else:
         bi = b


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes https://github.com/biolab/orange3/issues/6715

gui.spin creates an extra widget box on the parent which interferes with mouse interaction

I.e:

![Screenshot_20240124_145723](https://github.com/biolab/orange-widget-base/assets/4716745/92b67071-4f55-46ac-b3af-2d2f02c5574b)

Note that the layout depends on the style, should be tested on Windows. 

##### Description of changes

Remove extraneous created widget box

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
