### PR TITLE
WidgetTest: Pass extra kwargs in create_widget to __new__

### DIFF
--- a/orangewidget/tests/base.py
+++ b/orangewidget/tests/base.py
@@ -309,8 +309,8 @@ class WidgetTest(GuiTest):
         self.signal_manager.clear()
         super().tearDown()
 
-    def create_widget(self, cls, stored_settings=None, reset_default_settings=True):
-        # type: (Type[T], Optional[dict], bool) -> T
+    def create_widget(self, cls: Type[T], stored_settings: Optional[dict]=None,
+                      reset_default_settings=True, **kwargs) -> T:
         """Create a widget instance using mock signal_manager.
 
         When used with default parameters, it also overrides settings stored
@@ -350,7 +350,7 @@ class WidgetTest(GuiTest):
         if reset_default_settings:
             self.reset_default_settings(Cls)
         widget = Cls.__new__(Cls, signal_manager=self.signal_manager,
-                             stored_settings=stored_settings)
+                             stored_settings=stored_settings, **kwargs)
         widget.__init__()
         self.process_events()
         self.widgets.append(widget)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

__new__ takes more parameters, this makes it difficult to test certain behaviors e.g. [test_owcsvimport in orange3 has reimplemented create_widget to pass env](https://github.com/biolab/orange3/blob/f43938d282a9794d111a603bb41117c80a7ea2d0/Orange/widgets/data/tests/test_owcsvimport.py#L38-L53)


##### Description of changes

Pass kwargs to widget __new__

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
