### PR TITLE
ListViewFilter: Retain selection when filtering

### DIFF
--- a/orangewidget/utils/listview.py
+++ b/orangewidget/utils/listview.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from typing import Iterable, Optional
 import warnings
 
@@ -14,14 +13,7 @@ from AnyQt.QtCore import (
     QItemSelectionModel,
 )
 
-
-@contextmanager
-def disconnected(signal, slot, connection_type=Qt.AutoConnection):
-    signal.disconnect(slot)
-    try:
-        yield
-    finally:
-        signal.connect(slot, connection_type)
+from orangewidget.utils.itemmodels import signal_blocking
 
 
 class ListViewFilter(QListView):
@@ -66,8 +58,7 @@ class ListViewFilter(QListView):
         self.__select()
 
     def __on_text_edited(self, string: str):
-        with disconnected(self.selectionModel().selectionChanged,
-                          self.__on_sel_changed):
+        with signal_blocking(self.selectionModel()):
             self.model().setFilterFixedString(string)
             self.__select()
 

--- a/orangewidget/utils/tests/test_listview.py
+++ b/orangewidget/utils/tests/test_listview.py
@@ -134,6 +134,21 @@ class TestListViewFilter(GuiTest):
     def test_set_proxy_raises(self):
         self.assertRaises(Exception, ListViewFilter, proxy=PyListModel())
 
+    def test_selection(self):
+        view = ListViewFilter()
+        view.model().setSourceModel(PyListModel(["one", "two", "three"]))
+        sel_model = view.selectionModel()
+        selected_row = 0
+        index = view.model().index(selected_row, 0)
+        sel_model.select(index, sel_model.ClearAndSelect)
+        self.assertEqual(sel_model.selectedRows(0)[0].row(), selected_row)
+
+        view._ListViewFilter__search.textEdited.emit("two")
+        self.assertEqual(len(sel_model.selectedRows(0)), 0)
+
+        view._ListViewFilter__search.textEdited.emit("")
+        self.assertEqual(sel_model.selectedRows(0)[0].row(), selected_row)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3/issues/6768

##### Description of changes
The default selection corresponds to `QSortFilterProxyModel`. 
Apply selection mapped to a source model.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
