### PR TITLE
Remove window help button

### DIFF
--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -314,6 +314,9 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         WidgetMessagesMixin.__init__(self)
         WidgetSignalsMixin.__init__(self)
 
+        # disable window help button everywhere
+        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
+
         # handle deprecated left_side_scrolling
         if hasattr(self, 'left_side_scrolling'):
             warnings.warn(


### PR DESCRIPTION
##### Issue
Fixes [#6799](https://github.com/biolab/orange3/issues/6799)

##### Description of changes
Help button was not present in all widgets, only in those with resizing disabled (e.g. CSV File Import, Data Info, Constant, kNN, ...), where the window type was Qt.Dialog instead of Qt.Window. Now it should be gone everywhere as we have our own.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
