### PR TITLE
WidgetMessagesMixin: Fix message binding to not expect class attributes to have `__eq__`

### DIFF
--- a/orangewidget/utils/messages.py
+++ b/orangewidget/utils/messages.py
@@ -192,9 +192,14 @@ class MessageGroup:
                     msg = msg.bind(self, widget_class)
                     self.__dict__[name] = msg
 
+        # Iterate through all base classes of this message group.
+        # Among the widgets in mro, find the one that defined this class
+        # and bind all messages in the group to that class.
+        # This is needed so that each message has its "owner" and that `clear`
+        # method can clear only messages from the owner (see method `clear`)
         for group in type(self).mro():
             for widget_class in type(self.widget).mro():
-                if group in widget_class.__dict__.values():
+                if widget_class.__dict__.get(group.__name__) is group:
                     break
             else:
                 # MessageGroups outside widget classes (e.g. mixins)

--- a/orangewidget/utils/tests/test_messages.py
+++ b/orangewidget/utils/tests/test_messages.py
@@ -35,6 +35,19 @@ class TestMessages(WidgetTest):
         self.assertFalse(w.Error.err_a.is_shown())
         self.assertTrue(w.Error.err_b.is_shown())
 
+    def test_numpy_class_attributes(self):
+        # There used to be a bug where numpy class attributes crash message
+        # binding it expected them to have __eq__ method (see other changes in
+        # this commit). This test is to make sure the problem doesn't resurface.
+        class Neq:
+            def __eq__(self, other):
+                raise NotImplementedError
+
+        class WidgetA(OWBaseWidget, openclass=True):
+            a = Neq()
+
+        self.create_widget(WidgetA)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue

Fixes #272. (@hoywu, thanks for catching this!)

Condition `group in widget_class.__dict__.values()` expected that all class members have an `__eq__` operator in which "other" can be a class (message group).

If somebody adds a numpy array or pandas dataframe as class attribute (e.g. `pd`), it will compare `group == pd`, which fails with `The truth value of a DataFrame is ambiguous.`.

##### Description of changes

We know the name of the attribute (the class name) and can check that the instance is the same (not just equal).

##### Includes
- [X] Code changes
- [X] Tests