### PR TITLE
[MNT] ci: Replace deprecated macos-11 GH runners

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -49,27 +49,27 @@ jobs:
             extra-system-packages: "libegl1-mesa libxcb-cursor0 glibc-tools"
 
           # macOS
-          - os: macos-11
+          - os: macos-12
             python-version: 3.8
             test-env: "PyQt5~=5.14.0 PyQtWebEngine~=5.14.0"
 
-          - os: macos-11
+          - os: macos-12
             python-version: 3.9
             test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0"
 
-          - os: macos-12
+          - os: macos-13
             python-version: "3.10"
             test-env: "PyQt5~=5.15.0 PyQtWebEngine~=5.15.0"
 
-          - os: macos-12
+          - os: macos-13
             python-version: "3.11"
             test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3 PyQt6-WebEngine~=6.2.1 PyQt6-WebEngine-Qt6~=6.2.1"
 
-          - os: macos-12
+          - os: macos-latest
             python-version: "3.11"
             test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0 PyQt6-WebEngine~=6.5.0 PyQt6-WebEngine-Qt6~=6.5.0"
 
-          - os: macos-12
+          - os: macos-latest
             python-version: "3.12"
             test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0 PyQt6-WebEngine~=6.5.0 PyQt6-WebEngine-Qt6~=6.5.0"
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

macos-11 github actions runners are deprecated. Replace them.

##### Description of changes

Replace deprecated macos-11 GH runners

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
