### PR TITLE
open_filename_dialog: Allow reading *.*

### DIFF
--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -930,6 +930,8 @@ utils/filedialogs.py:
         Save as...: Shrani kot...
     def `open_filename_dialog`:
         Open...: Odpri...
+        *: false
+        All files (*.*): Vse datoteke (*.*)
         All readable files (*{}): Vse znane datoteke (*{})
         ' *': false
         ;;: false
@@ -1080,6 +1082,7 @@ utils/matplotlib_export.py:
         \n: false
     def `scene_code`:
         import matplotlib.pyplot as plt: false
+        import numpy as np: false
         from numpy import array: false
         plt.clf(): false
         bottom: false

--- a/orangewidget/utils/filedialogs.py
+++ b/orangewidget/utils/filedialogs.py
@@ -162,8 +162,8 @@ def open_filename_dialog(start_dir: str, start_filter: str, file_formats,
         start_dir (str): initial directory, optionally including the filename
         start_filter (str): initial filter
         file_formats (a list of FileFormat): file formats
-        add_all (bool, default True): add a filter for all supported extensions.
-           If set to `*`, show an option to read all files, *.*.
+        add_all (False, True, or `"*"`; default True): add a filter for all supported extensions.
+           If set to `"*"`, show an option to read all files, *.*.
         title (str): title of the dialog
         dialog: a function that creates a QT dialog
     Returns:

--- a/orangewidget/utils/filedialogs.py
+++ b/orangewidget/utils/filedialogs.py
@@ -162,7 +162,8 @@ def open_filename_dialog(start_dir: str, start_filter: str, file_formats,
         start_dir (str): initial directory, optionally including the filename
         start_filter (str): initial filter
         file_formats (a list of FileFormat): file formats
-        add_all (bool): add a filter for all supported extensions
+        add_all (bool, default True): add a filter for all supported extensions.
+           If set to `*`, show an option to read all files, *.*.
         title (str): title of the dialog
         dialog: a function that creates a QT dialog
     Returns:
@@ -172,7 +173,10 @@ def open_filename_dialog(start_dir: str, start_filter: str, file_formats,
     filters = [format_filter(f) for f in file_formats]
 
     # add all readable files option
-    if add_all:
+    if add_all == "*":
+        file_formats.insert(0, None)
+        filters.insert(0, "All files (*.*)")
+    elif add_all and len(file_formats) > 1:
         all_extensions = set()
         for f in file_formats:
             all_extensions.update(f.EXTENSIONS)

--- a/orangewidget/utils/tests/test_filedialogs.py
+++ b/orangewidget/utils/tests/test_filedialogs.py
@@ -132,6 +132,54 @@ class TestOpenFilenameDialog(unittest.TestCase):
         self.assertEqual(file_format, None)
         self.assertEqual(file_filter, None)
 
+    def test_add_all(self):
+        class ABCFormat:
+            EXTENSIONS = ('.abc', '.jkl')
+            DESCRIPTION = 'abc file'
+            PRIORITY = 30
+
+        class DEFFormat:
+            EXTENSIONS = ('.def', )
+            DESCRIPTION = 'def file'
+            PRIORITY = 40
+
+        # Add all known extensions
+        dialog = Mock(return_value=("foo.abc", ""))
+        open_filename_dialog(".", "", [ABCFormat, DEFFormat], dialog=dialog)
+        self.assertIn("(*.abc *.def *.jkl)", dialog.call_args[0][3])
+        self.assertIn("(*.abc *.jkl)", dialog.call_args[0][3])
+        self.assertIn("(*.def)", dialog.call_args[0][3])
+
+        # Add all extensions (*.*)
+        dialog = Mock(return_value=("foo.abc", ""))
+        open_filename_dialog(".", "", [ABCFormat, DEFFormat],
+                             add_all="*", dialog=dialog)
+        self.assertIn("(*.*)", dialog.call_args[0][3])
+        self.assertIn("(*.abc *.jkl)", dialog.call_args[0][3])
+        self.assertIn("(*.def)", dialog.call_args[0][3])
+
+        # Don't add any extensions
+        dialog = Mock(return_value=("foo.abc", ""))
+        open_filename_dialog(".", "", [ABCFormat, DEFFormat],
+                             add_all=False, dialog=dialog)
+        self.assertNotIn("(*.abc *.def *.jkl)", dialog.call_args[0][3])
+        self.assertIn("(*.abc *.jkl)", dialog.call_args[0][3])
+        self.assertIn("(*.def)", dialog.call_args[0][3])
+
+        # With a single format, add all known extensions is ignored
+        dialog = Mock(return_value=("foo.abc", ""))
+        open_filename_dialog(".", "", [ABCFormat],
+                             dialog=dialog)
+        self.assertNotIn("(*.*)", dialog.call_args[0][3])
+        self.assertEqual(dialog.call_args[0][3].count("(*.abc *.jkl)"), 1)
+
+        # With a single format, add all extensions (*.*) still applies
+        dialog = Mock(return_value=("foo.abc", ""))
+        open_filename_dialog(".", "", [ABCFormat],
+                             add_all="*", dialog=dialog)
+        self.assertIn("(*.*)", dialog.call_args[0][3])
+        self.assertIn("(*.abc *.jkl)", dialog.call_args[0][3])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue

`open_filename_dialog` has an argument `add_all` which, if `True`, adds "All readable files" that allows loading a file with any known extension. This is not enough to implement https://github.com/biolab/orange3/issues/6792.

##### Description of changes

- If `add_all` is set to `*` it offers all extensions (*.*), not just the known.
- An unrelated improvement: if there is only a single file format, "All readable files" makes no sense and is not shown. This is situation might be common - there may be only a single file format and the caller forgets to change the default value of `add_all` from `True` to `False`.
- 
- ##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
