### PR TITLE
Report: Fix saving to PDF

### DIFF
--- a/orangewidget/report/owreport.py
+++ b/orangewidget/report/owreport.py
@@ -11,7 +11,8 @@ from enum import IntEnum
 from typing import Optional
 
 from AnyQt.QtCore import Qt, QObject, pyqtSlot, QSize
-from AnyQt.QtGui import QIcon, QCursor, QStandardItemModel, QStandardItem
+from AnyQt.QtGui import (
+    QIcon, QCursor, QStandardItemModel, QStandardItem, QPageSize)
 from AnyQt.QtWidgets import (
     QApplication, QDialog, QFileDialog, QTableView, QHeaderView,
     QMessageBox)
@@ -354,7 +355,7 @@ class OWReport(OWBaseWidget):
         _, extension = os.path.splitext(filename)
         if extension == ".pdf":
             printer = QPrinter()
-            printer.setPageSize(QPrinter.A4)
+            printer.setPageSize(QPageSize.A4)
             printer.setOutputFormat(QPrinter.PdfFormat)
             printer.setOutputFileName(filename)
             self._print_to_printer(printer)

--- a/orangewidget/report/owreport.py
+++ b/orangewidget/report/owreport.py
@@ -355,7 +355,7 @@ class OWReport(OWBaseWidget):
         _, extension = os.path.splitext(filename)
         if extension == ".pdf":
             printer = QPrinter()
-            printer.setPageSize(QPageSize.A4)
+            printer.setPageSize(QPageSize(QPageSize.A4))
             printer.setOutputFormat(QPrinter.PdfFormat)
             printer.setOutputFileName(filename)
             self._print_to_printer(printer)

--- a/orangewidget/report/tests/test_report.py
+++ b/orangewidget/report/tests/test_report.py
@@ -79,22 +79,32 @@ class TestReport(GuiTest):
                 rep.save_report()
                 log.assert_called()
 
-    def test_save_report(self):
+    def _test_save_report(self, filter):
+        ext = re.search(r"\.(?P<format>\w+)\)$", filter).group("format")
         rep = OWReport()
         widget = TstWidget()
         widget.create_report_html()
         rep.make_report(widget)
-        temp_dir = tempfile.mkdtemp()
-        temp_name = os.path.join(temp_dir, "f.report")
+        temp_f = tempfile.NamedTemporaryFile("w", suffix=f".{ext}", delete=False)
+        temp_name = temp_f.name
+        temp_f.close()
         try:
             with patch("AnyQt.QtWidgets.QFileDialog.getSaveFileName",
-                       return_value=(temp_name, 'Report (*.report)')), \
+                       return_value=(temp_name, filter)), \
                     patch("AnyQt.QtWidgets.QMessageBox.exec",
                           return_value=True):
                 rep.save_report()
         finally:
             os.remove(temp_name)
-            os.rmdir(temp_dir)
+
+    def test_save_report_pdf(self):
+        self._test_save_report("PDF (*.pdf)")
+
+    def test_save_report_html(self):
+        self._test_save_report("HTML (*.html)")
+
+    def test_save_report_(self):
+        self._test_save_report("Report (*.report)")
 
     @patch("AnyQt.QtWidgets.QFileDialog.getSaveFileName",
            return_value=(False, 'HTML (*.html)'))


### PR DESCRIPTION
##### Issue

In Qt6, `QPrinter` no longer contains an enum with page sizes, e.g. `QPrinter.A4`. I haven't found a notice that enum is obsolete and removed, but I found [this](https://doc.qt.io/qt-5/qprinter-obsolete.html#setPaperSize).

To reproduce, on macOS:

- Report something
- Click Print
- Choose PDF -> Save as PDF ...
- Enter file name, click Save

Crashes with 

```
File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/orangewidget/report/owreport.py", line 350, in save_report
    printer.setPageSize(QPrinter.A4)
                        ^^^^^^^^^^^
AttributeError: type object 'QPrinter' has no attribute 'A4'
```

##### Description of changes

Use `QPageSize`.

##### Includes
- [X] Code changes