### PR TITLE
[FIX] widget: Make controlAreaVisible a global setting

### DIFF
--- a/orangewidget/widget.py
+++ b/orangewidget/widget.py
@@ -298,7 +298,7 @@ class OWBaseWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     messageDeactivated = Signal(Msg)
 
     savedWidgetGeometry = settings.Setting(None)
-    controlAreaVisible = settings.Setting(True, schema_only=True)
+    controlAreaVisible = settings.Setting(True)
 
     __report_action = None  # type: Optional[QAction]
     __save_image_action = None  # type: Optional[QAction]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Make controlAreaVisible a global setting along the widget geometry.

##### Description of changes

Make controlAreaVisible a global setting

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
