### PR TITLE
Matplotlib export: Fix code for different shapes and sizes

### DIFF
--- a/orangewidget/utils/matplotlib_export.py
+++ b/orangewidget/utils/matplotlib_export.py
@@ -84,7 +84,7 @@ def scatterplot_code(scatterplot_item):
 
     code.append("# style")
     sizes = compress_if_all_same(sizes)
-    if sizes == -1:
+    if np.all(sizes == -1):
         sizes = None
     code.append("sizes = {}".format(numpy_repr(sizes)))
 
@@ -167,8 +167,8 @@ def scatterplot_code(scatterplot_item):
     # each marker requires one call to matplotlib's scatter!
     markers = np.array([matplotlib_marker(m) for m in scatterplot_item.data["symbol"]])
     for m in set(markers):
-        indices = np.where(markers == m)[0]
-        if np.all(indices == np.arange(x.shape[0])):
+        indices = np.nonzero(markers == m)[0]
+        if len(indices) == x.shape[0]:
             indices = None
         if indices is not None:
             code.append("indices = {}".format(numpy_repr_int(indices)))

--- a/orangewidget/utils/tests/test_matplotlib_export.py
+++ b/orangewidget/utils/tests/test_matplotlib_export.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import Mock
+
+from pyqtgraph.graphicsItems.ScatterPlotItem import ScatterPlotItem
+from orangewidget.tests.base import GuiTest
+from orangewidget.utils.matplotlib_export import scatterplot_code
+
+
+class TestScatterplotCode(GuiTest):
+    def setUp(self):
+        self.item = ScatterPlotItem([1, 2, 3], [4, 5, 6])
+
+    def test_export(self):
+        # We can't really test the code (without assuming a particular format),
+        # but we can at least check that it runs without error
+        scatterplot_code(self.item)
+
+        self.item.setSize([10, 20, 30])
+        scatterplot_code(self.item)
+
+        self.item.setPen([2, 2, 3])
+        scatterplot_code(self.item)
+
+        self.item.setBrush(["r", "g", "g"])
+        scatterplot_code(self.item)
+
+        self.item.setSymbol(["o", "o", "t"])
+        scatterplot_code(self.item)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### Issue

Fixes https://github.com/biolab/orange3/issues/7258.

##### Description of changes

- Different sizes failed because of `sizes == -1` where `sizes` could be an array. `np.all` works is safer.
- In fixing incorrect code for different shapes I also replace `np.where` with the preferred `np.nonzero` (though result is the same).

##### Includes
- [X] Code changes
- [X] Tests
