### PR TITLE
[FIX] itemmodels: Do not return the separator instance from `data()`

### DIFF
--- a/orangewidget/utils/itemmodels.py
+++ b/orangewidget/utils/itemmodels.py
@@ -596,14 +596,18 @@ class PyListModel(QAbstractListModel):
         return 0 if parent.isValid() else 1
 
     def data(self, index, role=Qt.DisplayRole):
+        if not self._is_index_valid(index):
+            return None
         row = index.row()
-        if role in [self.list_item_role, Qt.EditRole] \
-                and self._is_index_valid(index):
-            return self[row]
-        elif self._is_index_valid(row):
-            if isinstance(self[row], SeparatorItem) \
-                    and role == Qt.AccessibleDescriptionRole:
-                return 'separator'
+        if role in [self.list_item_role, Qt.EditRole]:
+            item = self[row]
+            if isinstance(item, SeparatorItem):
+                return None
+            return item
+        elif (role == Qt.AccessibleDescriptionRole and
+              isinstance(self[row], SeparatorItem)):
+            return 'separator'
+        else:
             return self._other_data[row].get(role, None)
 
     def itemData(self, index):

--- a/orangewidget/utils/tests/test_itemmodels.py
+++ b/orangewidget/utils/tests/test_itemmodels.py
@@ -659,8 +659,11 @@ class TestPyListModel(unittest.TestCase):
         model += [1, model.Separator]
         model.extend([1, model.Separator])
         for i in range(len(model)):
-            self.assertIs(model.flags(model.index(i)) == Qt.NoItemFlags,
-                          i % 2 != 0, f"in row {i}")
+            if i % 2:
+                midx = model.index(i)
+                self.assertIs(midx.data(Qt.DisplayRole), None)
+                self.assertEqual(midx.data(Qt.AccessibleDescriptionRole), "separator")
+                self.assertEqual(midx.flags(), Qt.NoItemFlags)
 
 
 class TestSeparatedListDelegate(unittest.TestCase):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

On PyQt6 6.11 the SeparatorItems str() is visible in searchable combo box popup view.
<img width="283" height="204" alt="Screenshot 2026-05-22 at 13 35 12" src="https://github.com/user-attachments/assets/000a03eb-e87f-4b77-97e7-bf436a31f26e" />

##### Description of changes

* Do not return the separator instance from `data()`

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
