### PR TITLE
[MNT] ci: Bump actions versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ jobs:
     name: Build distribution files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -25,7 +25,7 @@ jobs:
         run: python -m build --wheel .
 
       - name: Upload dist files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-sdist
           path: dist/*
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           # unpacks all dist artifacts into dist/
           pattern: dist-*
@@ -61,7 +61,7 @@ jobs:
     if: always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags')
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           # unpacks all dist artifacts into dist/
           pattern: dist-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,4 +73,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: dist/
+          packages-dir: dist/

--- a/.github/workflows/run-docs-build.yml
+++ b/.github/workflows/run-docs-build.yml
@@ -19,14 +19,14 @@ jobs:
             python: "3.10"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
       - name: Setup Pip Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .pip-cache
           key: ${{ runner.os }}-py-${{ matrix.python }}-pip-${{ hashFiles('setup.*', '.github/workflows/run-docs-build.yml') }}

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -101,9 +101,9 @@ jobs:
             test-env: "PyQt6~=6.11.0 PyQt6-Qt6~=6.11.0 PyQt6-WebEngine~=6.11.0 PyQt6-WebEngine-Qt6~=6.11.0"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -117,7 +117,7 @@ jobs:
           sudo apt-get install -y $UBUNTU_SYSTEM_PACKAGES $PACKAGES
 
       - name: Setup Pip Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .pip-cache
           key: ${{ runner.os }}-py-${{ matrix.python-version }}-pip-${{ hashFiles('setup.*', '.github/workflows/run-tests-workflow.yml') }}
@@ -153,6 +153,6 @@ jobs:
           coverage xml
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

From CI logs:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4, actions/setup-python@v5, codecov/codecov-action@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. 


##### Description of changes

* Bump gh actions versions to avoid Node 20 deprecation warnings in CI logs

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
